### PR TITLE
Fix race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-if: tag IS blank
-
 matrix:
   include:
     - os: linux

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -1,12 +1,47 @@
 #!/bin/bash
 
-if git rev-parse $LATEST_MS_TAG >/dev/null 2>&1
-then
-    echo "Latest MS tag ${LATEST_MS_TAG} already exists in VSCodium. Bail"
+GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/vscodium/vscodium/releases/tags/$LATEST_MS_TAG)
+echo "Github response: ${GITHUB_RESPONSE}"
+VSCODIUM_ASSETS=$(echo $GITHUB_RESPONSE | jq '.assets')
+echo "VSCodium assets: ${VSCODIUM_ASSETS}"
+
+if [ "$VSCODIUM_ASSETS" != "null" ]; then
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["zip"])')
+    if [[ "$HAVE_MAC" != "true" ]]; then
+      echo "Building on Mac because we have no ZIP"
+      export SHOULD_BUILD="yes"
+    fi
+  else
+    HAVE_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["rpm"])')
+    HAVE_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["deb"])')
+    HAVE_TAR=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["tar.gz"])')
+    if [[ "$HAVE_RPM" != "true" ]]; then
+      echo "Building on Linux because we have no RPM"
+      export SHOULD_BUILD="yes"
+    fi
+    if [[ "$HAVE_DEB" != "true" ]]; then
+      echo "Building on Linux because we have no DEB"
+      export SHOULD_BUILD="yes"
+    fi
+    if [[ "$HAVE_TAR" != "true" ]]; then
+      echo "Building on Linux because we have no TAR"
+      export SHOULD_BUILD="yes"
+    fi
+    if [[ "$SHOULD_BUILD" != "yes" ]]; then
+      echo "Already have all the Linux builds"
+    fi
+  fi
 else
-    echo "New MS tag found, continuing build"
+  echo "Release assets do not exist at all, continuing build"
+  export SHOULD_BUILD="yes"
+  if git rev-parse $LATEST_MS_TAG >/dev/null 2>&1
+  then
+    export TRAVIS_TAG=$LATEST_MS_TAG
+  else
     git config --local user.name "Travis CI"
     git config --local user.email "builds@travis-ci.com"
     git tag $LATEST_MS_TAG
-    export SHOULD_BUILD="yes"
+  fi
 fi
+

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -5,43 +5,46 @@ echo "Github response: ${GITHUB_RESPONSE}"
 VSCODIUM_ASSETS=$(echo $GITHUB_RESPONSE | jq '.assets')
 echo "VSCodium assets: ${VSCODIUM_ASSETS}"
 
-if [ "$VSCODIUM_ASSETS" != "null" ]; then
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["zip"])')
-    if [[ "$HAVE_MAC" != "true" ]]; then
-      echo "Building on Mac because we have no ZIP"
-      export SHOULD_BUILD="yes"
+# if we just don't have the github token, get out fast
+if [ "$GITHUB_TOKEN" != "" ]; then
+  if [ "$VSCODIUM_ASSETS" != "null" ]; then
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["zip"])')
+      if [[ "$HAVE_MAC" != "true" ]]; then
+        echo "Building on Mac because we have no ZIP"
+        export SHOULD_BUILD="yes"
+      fi
+    else
+      HAVE_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["rpm"])')
+      HAVE_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["deb"])')
+      HAVE_TAR=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["tar.gz"])')
+      if [[ "$HAVE_RPM" != "true" ]]; then
+        echo "Building on Linux because we have no RPM"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_DEB" != "true" ]]; then
+        echo "Building on Linux because we have no DEB"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_TAR" != "true" ]]; then
+        echo "Building on Linux because we have no TAR"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$SHOULD_BUILD" != "yes" ]]; then
+        echo "Already have all the Linux builds"
+      fi
     fi
   else
-    HAVE_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["rpm"])')
-    HAVE_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["deb"])')
-    HAVE_TAR=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["tar.gz"])')
-    if [[ "$HAVE_RPM" != "true" ]]; then
-      echo "Building on Linux because we have no RPM"
-      export SHOULD_BUILD="yes"
+    echo "Release assets do not exist at all, continuing build"
+    export SHOULD_BUILD="yes"
+    if git rev-parse $LATEST_MS_TAG >/dev/null 2>&1
+    then
+      export TRAVIS_TAG=$LATEST_MS_TAG
+    else
+      git config --local user.name "Travis CI"
+      git config --local user.email "builds@travis-ci.com"
+      git tag $LATEST_MS_TAG
     fi
-    if [[ "$HAVE_DEB" != "true" ]]; then
-      echo "Building on Linux because we have no DEB"
-      export SHOULD_BUILD="yes"
-    fi
-    if [[ "$HAVE_TAR" != "true" ]]; then
-      echo "Building on Linux because we have no TAR"
-      export SHOULD_BUILD="yes"
-    fi
-    if [[ "$SHOULD_BUILD" != "yes" ]]; then
-      echo "Already have all the Linux builds"
-    fi
-  fi
-else
-  echo "Release assets do not exist at all, continuing build"
-  export SHOULD_BUILD="yes"
-  if git rev-parse $LATEST_MS_TAG >/dev/null 2>&1
-  then
-    export TRAVIS_TAG=$LATEST_MS_TAG
-  else
-    git config --local user.name "Travis CI"
-    git config --local user.email "builds@travis-ci.com"
-    git tag $LATEST_MS_TAG
   fi
 fi
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,5 +5,6 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install yarn --without-node
   brew install jq zip
 else
+  sudo apt-get update
   sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm
 fi


### PR DESCRIPTION
Used to check if VSCodium had the latest MS tag, and if so, not build. If the tag wasn't there, build.

But since the builds are running in parallel on OSX and Linux, if one finished before the other, it was possible for the other one to not build and upload its assets.

This new approach hits the Github API to determine if the tag exists and if so, which assets have already been uploaded (rpm, deb for linux; zip for mac). If the build OS's asset isn't in the release, it will continue with the build+upload.