### PR TITLE
32 bit builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ matrix:
   include:
     - os: linux
       sudo: required
+    - os: linux
+      sudo: required
+      env: BUILDARCH=32
     - os: osx
 
 language: node_js
@@ -28,6 +31,8 @@ deploy:
   file:
     - ./*.zip
     - ./*.tar.gz
+    - vscode/.build/linux/deb/i386/deb/*.deb
+    - vscode/.build/linux/rpm/i386/*.rpm
     - vscode/.build/linux/deb/amd64/deb/*.deb
     - vscode/.build/linux/rpm/x86_64/*.rpm
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       sudo: required
     - os: linux
       sudo: required
-      env: BUILDARCH=32
+      env: BUILDARCH=ia32
     - os: osx
 
 language: node_js

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Microsoft's build process does download additional files. This was brought up in
 
 ## <a id="supported-os"></a>Supported OS
 - [x] OSX x64 (zipped app file)
-- [x] Linux x64 (`.deb`, `.rpm`, and `.tar.gz` files) 
-- [ ] Windows x64
+- [x] Linux x64 (`.deb`, `.rpm`, and `.tar.gz` files)
+- [x] Linux x86 (`.deb`, `.rpm`, and `.tar.gz` files)
+- [ ] Windows
   - The plan is to build the Windows executable with [AppVeyor](https://appveyor.com). PRs are welcome :blue_heart:
   
-32-bit x86 and ARM architectures are not currently supported. If you know of a way to do this with Travis or any other free CI/CD platform please put in an issue or a PR.
+The ARM architecture is not currently supported. If you know of a way to do this with Travis or any other free CI/CD platform please put in an issue or a PR.
 
 ## <a id="extensions-marketplace"></a>Extensions + Marketplace
 Until something more open comes around, we use the Microsoft Marketplace/Extensions in the `product.json` file. Those links are licensed under MIT as per [the comments on this issue.](https://github.com/Microsoft/vscode/issues/31168#issuecomment-317319063)

--- a/build.sh
+++ b/build.sh
@@ -22,15 +22,15 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   fi
 
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    npx gulp vscode-darwin-min
+    npm run gulp vscode-darwin-min
   elif [[ "$BUILDARCH" == "32" ]]; then
-    npx gulp vscode-linux-ia32-min
-    npx gulp vscode-linux-ia32-build-deb
-    npx gulp vscode-linux-ia32-build-rpm
+    npm run gulp vscode-linux-ia32-min
+    npm run gulp vscode-linux-ia32-build-deb
+    npm run gulp vscode-linux-ia32-build-rpm
   else
-    npx gulp vscode-linux-x64-min
-    npx gulp vscode-linux-x64-build-deb
-    npx gulp vscode-linux-x64-build-rpm
+    npm run gulp vscode-linux-x64-min
+    npm run gulp vscode-linux-x64-build-deb
+    npm run gulp vscode-linux-x64-build-rpm
   fi
 
   cd ..

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
 
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     npx gulp vscode-darwin-min
-  else if [[ "$BUILDARCH" == "32" ]]; then
+  elif [[ "$BUILDARCH" == "32" ]]; then
     npx gulp vscode-linux-ia32-min
     npx gulp vscode-linux-ia32-build-deb
     npx gulp vscode-linux-ia32-build-rpm

--- a/build.sh
+++ b/build.sh
@@ -2,20 +2,32 @@
 
 if [[ "$SHOULD_BUILD" == "yes" ]]; then
   cd vscode
+
+  if [[ "$BUILDARCH" == "32" ]]; then
+    export npm_config_arch=ia32
+  fi
+
   yarn
   mv product.json product.json.bak
   cat product.json.bak | jq 'setpath(["extensionsGallery"]; {"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery", "cacheUrl": "https://vscode.blob.core.windows.net/gallery/index", "itemUrl": "https://marketplace.visualstudio.com/items"}) | setpath(["nameShort"]; "VSCodium") | setpath(["nameLong"]; "VSCodium") | setpath(["applicationName"]; "vscodium") | setpath(["win32MutexName"]; "vscodium") | setpath(["win32DirName"]; "VSCodium") | setpath(["win32NameVersion"]; "VSCodium") | setpath(["win32RegValueName"]; "VSCodium") | setpath(["win32AppUserModelId"]; "Microsoft.VSCodium") | setpath(["win32ShellNameShort"]; "V&SCodium") | setpath(["urlProtocol"]; "vscodium")' > product.json
   cat product.json
   export NODE_ENV=production
 
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    npx gulp vscode-darwin-min
-  else
+  if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     # microsoft adds their apt repo to sources
     # unless the app name is code-oss
     # as we are renaming the application to vscodium
     # we need to edit a line in the post install template
     sed -i "s/code-oss/vscodium/" resources/linux/debian/postinst.template
+  fi
+
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    npx gulp vscode-darwin-min
+  else if [[ "$BUILDARCH" == "32" ]]; then
+    npx gulp vscode-linux-ia32-min
+    npx gulp vscode-linux-ia32-build-deb
+    npx gulp vscode-linux-ia32-build-rpm
+  else
     npx gulp vscode-linux-x64-min
     npx gulp vscode-linux-x64-build-deb
     npx gulp vscode-linux-x64-build-rpm

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 if [[ "$SHOULD_BUILD" == "yes" ]]; then
   cd vscode
 
-  if [[ "$BUILDARCH" == "32" ]]; then
+  if [[ "$BUILDARCH" == "ia32" ]]; then
     export npm_config_arch=ia32
   fi
 
@@ -23,10 +23,11 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
 
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     npm run gulp vscode-darwin-min
-  elif [[ "$BUILDARCH" == "32" ]]; then
+  elif [[ "$BUILDARCH" == "ia32" ]]; then
     npm run gulp vscode-linux-ia32-min
     npm run gulp vscode-linux-ia32-build-deb
     npm run gulp vscode-linux-ia32-build-rpm
+    unset npm_config_arch
   else
     npm run gulp vscode-linux-x64-min
     npm run gulp vscode-linux-x64-build-deb

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -14,24 +14,24 @@ if [ "$GITHUB_TOKEN" != "" ]; then
         echo "Building on Mac because we have no ZIP"
         export SHOULD_BUILD="yes"
       fi
-    elif [[ $BUILDARCH == "32" ]]; then
-      HAVE_32_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.rpm"])')
-      HAVE_32_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.deb"])')
-      HAVE_32_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "ia32-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
-      if [[ "$HAVE_32_RPM" != "true" ]]; then
-        echo "Building on Linux x32 because we have no RPM"
+    elif [[ $BUILDARCH == "ia32" ]]; then
+      HAVE_IA32_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.rpm"])')
+      HAVE_IA32_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.deb"])')
+      HAVE_IA32_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "ia32-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+      if [[ "$HAVE_IA32_RPM" != "true" ]]; then
+        echo "Building on Linux ia32 because we have no RPM"
         export SHOULD_BUILD="yes"
       fi
-      if [[ "$HAVE_32_DEB" != "true" ]]; then
-        echo "Building on Linux x32 because we have no DEB"
+      if [[ "$HAVE_IA32_DEB" != "true" ]]; then
+        echo "Building on Linux ia32 because we have no DEB"
         export SHOULD_BUILD="yes"
       fi
-      if [[ "$HAVE_32_TAR" != "true" ]]; then
-        echo "Building on Linux x32 because we have no TAR"
+      if [[ "$HAVE_IA32_TAR" != "true" ]]; then
+        echo "Building on Linux ia32 because we have no TAR"
         export SHOULD_BUILD="yes"
       fi
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
-        echo "Already have all the Linux x32 builds"
+        echo "Already have all the Linux ia32 builds"
       fi
     else
       HAVE_64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["x86_64.rpm"])')

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -14,7 +14,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
         echo "Building on Mac because we have no ZIP"
         export SHOULD_BUILD="yes"
       fi
-    else if [[ $BUILDARCH == "32" ]]; then
+    elif [[ $BUILDARCH == "32" ]]; then
       HAVE_32_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.rpm"])')
       HAVE_32_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.deb"])')
       HAVE_32_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "ia32-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -14,37 +14,56 @@ if [ "$GITHUB_TOKEN" != "" ]; then
         echo "Building on Mac because we have no ZIP"
         export SHOULD_BUILD="yes"
       fi
-    else
-      HAVE_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["rpm"])')
-      HAVE_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["deb"])')
-      HAVE_TAR=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["tar.gz"])')
-      if [[ "$HAVE_RPM" != "true" ]]; then
-        echo "Building on Linux because we have no RPM"
+    else if [[ $BUILDARCH == "32" ]]; then
+      HAVE_32_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.rpm"])')
+      HAVE_32_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["i386.deb"])')
+      HAVE_32_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "ia32-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+      if [[ "$HAVE_32_RPM" != "true" ]]; then
+        echo "Building on Linux x32 because we have no RPM"
         export SHOULD_BUILD="yes"
       fi
-      if [[ "$HAVE_DEB" != "true" ]]; then
-        echo "Building on Linux because we have no DEB"
+      if [[ "$HAVE_32_DEB" != "true" ]]; then
+        echo "Building on Linux x32 because we have no DEB"
         export SHOULD_BUILD="yes"
       fi
-      if [[ "$HAVE_TAR" != "true" ]]; then
-        echo "Building on Linux because we have no TAR"
+      if [[ "$HAVE_32_TAR" != "true" ]]; then
+        echo "Building on Linux x32 because we have no TAR"
         export SHOULD_BUILD="yes"
       fi
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
-        echo "Already have all the Linux builds"
+        echo "Already have all the Linux x32 builds"
+      fi
+    else
+      HAVE_64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["x86_64.rpm"])')
+      HAVE_64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["amd64.deb"])')
+      HAVE_64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "x64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+      if [[ "$HAVE_64_RPM" != "true" ]]; then
+        echo "Building on Linux x64 because we have no RPM"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_64_DEB" != "true" ]]; then
+        echo "Building on Linux x64 because we have no DEB"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_64_TAR" != "true" ]]; then
+        echo "Building on Linux x64 because we have no TAR"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$SHOULD_BUILD" != "yes" ]]; then
+        echo "Already have all the Linux x64 builds"
       fi
     fi
   else
     echo "Release assets do not exist at all, continuing build"
     export SHOULD_BUILD="yes"
-    if git rev-parse $LATEST_MS_TAG >/dev/null 2>&1
-    then
-      export TRAVIS_TAG=$LATEST_MS_TAG
-    else
-      git config --local user.name "Travis CI"
-      git config --local user.email "builds@travis-ci.com"
-      git tag $LATEST_MS_TAG
-    fi
+  fi
+  if git rev-parse $LATEST_MS_TAG >/dev/null 2>&1
+  then
+    export TRAVIS_TAG=$LATEST_MS_TAG
+  else
+    git config --local user.name "Travis CI"
+    git config --local user.email "builds@travis-ci.com"
+    git tag $LATEST_MS_TAG
   fi
 fi
 

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -4,7 +4,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     cd VSCode-darwin
     zip -r ../VSCode-darwin-${LATEST_MS_TAG}.zip ./*
-  else if [[ "$BUILDARCH" == "32" ]]; then
+  elif [[ "$BUILDARCH" == "32" ]]; then
     cd VSCode-linux-ia32
     tar czf ../VSCode-linux-ia32-${LATEST_MS_TAG}.tar.gz .
   else

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -4,7 +4,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     cd VSCode-darwin
     zip -r ../VSCode-darwin-${LATEST_MS_TAG}.zip ./*
-  elif [[ "$BUILDARCH" == "32" ]]; then
+  elif [[ "$BUILDARCH" == "ia32" ]]; then
     cd VSCode-linux-ia32
     tar czf ../VSCode-linux-ia32-${LATEST_MS_TAG}.tar.gz .
   else

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -4,6 +4,9 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     cd VSCode-darwin
     zip -r ../VSCode-darwin-${LATEST_MS_TAG}.zip ./*
+  else if [[ "$BUILDARCH" == "32" ]]; then
+    cd VSCode-linux-ia32
+    tar czf ../VSCode-linux-ia32-${LATEST_MS_TAG}.tar.gz .
   else
     cd VSCode-linux-x64
     tar czf ../VSCode-linux-x64-${LATEST_MS_TAG}.tar.gz .

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -7,7 +7,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 else
   sudo apt-get update
   sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm
-  if [[ "$BUILDARCH" == "32" ]]; then
+  if [[ "$BUILDARCH" == "ia32" ]]; then
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -7,4 +7,10 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 else
   sudo apt-get update
   sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm
+  if [[ "$BUILDARCH" == "32" ]]; then
+    sudo dpkg --add-architecture i386
+    sudo apt-get update
+    sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib
+    sudo apt-get install libx11-dev:i386 libxkbfile-dev:i386
+  fi
 fi


### PR DESCRIPTION
Thanks to @JL2210 for starting this initiative. Ended up running the 32-bit builds in a separate linux environment and using an env var to determine certain things.

changes:
- set the `npm_config_arch` env var to `ia32` before running `yarn` if building 32-bit
- install 32-bit dependencies (libc6-dev-i386, gcc-multilib, g++-multilib, libx11-dev:i386, libxkbfile-dev:i386) if building 32-bit
- adjust the check_tags logic to account for 64-bit vs 32-bit built linux files
- move the setting of the current tag -- there was a bug where builds would be deployed as untagged and this should fix that
- update README for 32-bit support
- stop using `npx` as the builds have a chance of overflowing the heap -- using MS's `npm run gulp` which sets a larger heap size during builds

built files are [here](https://github.com/stripedpajamas/vscodium/releases/tag/1.27.2) if anyone wants to test before merging