### PR TITLE
arm64 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ deploy:
     - vscode/.build/linux/rpm/i386/*.rpm
     - vscode/.build/linux/deb/amd64/deb/*.deb
     - vscode/.build/linux/rpm/x86_64/*.rpm
+    - vscode/.build/linux/deb/arm64/deb/*.deb
   on:
     all_branches: true
     condition: $SHOULD_BUILD = yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ matrix:
     - os: linux
       sudo: required
       env: BUILDARCH=ia32
+    - os: linux
+      sudo: required
+      env: BUILDARCH=arm64
     - os: osx
 
 language: node_js

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   elif [[ "$BUILDARCH" == "arm64" ]]; then
     npm run gulp vscode-linux-arm64-min
     npm run gulp vscode-linux-arm64-build-deb
-    npm run gulp vscode-linux-arm64-build-rpm
+    # npm run gulp vscode-linux-arm64-build-rpm
   else
     npm run gulp vscode-linux-x64-min
     npm run gulp vscode-linux-x64-build-deb

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,10 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-linux-ia32-build-deb
     npm run gulp vscode-linux-ia32-build-rpm
     unset npm_config_arch
+  elif [[ "$BUILDARCH" == "arm64" ]]; then
+    npm run gulp vscode-linux-arm64-min
+    npm run gulp vscode-linux-arm64-build-deb
+    npm run gulp vscode-linux-arm64-build-rpm
   else
     npm run gulp vscode-linux-x64-min
     npm run gulp vscode-linux-x64-build-deb

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/435vic/vscodium/releases/tags/$LATEST_MS_TAG)
+GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/VSCodium/vscodium/releases/tags/$LATEST_MS_TAG)
 echo "Github response: ${GITHUB_RESPONSE}"
 VSCODIUM_ASSETS=$(echo $GITHUB_RESPONSE | jq '.assets')
 echo "VSCodium assets: ${VSCODIUM_ASSETS}"

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -34,13 +34,13 @@ if [ "$GITHUB_TOKEN" != "" ]; then
         echo "Already have all the Linux ia32 builds"
       fi
     elif [[ $BUILDARCH == "arm64" ]]; then
-      HAVE_ARM64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.rpm"])')
+      # HAVE_ARM64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.rpm"])')
       HAVE_ARM64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.deb"])')
       HAVE_ARM64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
-      if [[ "$HAVE_ARM64_RPM" != "true" ]]; then
-        echo "Building on Linux arm64 because we have no RPM"
-        export SHOULD_BUILD="yes"
-      fi
+      # if [[ "$HAVE_ARM64_RPM" != "true" ]]; then
+      #   echo "Building on Linux arm64 because we have no RPM"
+      #   export SHOULD_BUILD="yes"
+      # fi
       if [[ "$HAVE_ARM64_DEB" != "true" ]]; then
         echo "Building on Linux arm64 because we have no DEB"
         export SHOULD_BUILD="yes"

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -33,7 +33,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
         echo "Already have all the Linux ia32 builds"
       fi
-    elif [[ $BUILDARCH == "arm64" ]] then
+    elif [[ $BUILDARCH == "arm64" ]]; then
       HAVE_ARM64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.rpm"])')
       HAVE_ARM64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.deb"])')
       HAVE_ARM64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -33,6 +33,25 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
         echo "Already have all the Linux ia32 builds"
       fi
+    elif [[ $BUILDARCH == "arm64" ]] then
+      HAVE_ARM64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.rpm"])')
+      HAVE_ARM64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.deb"])')
+      HAVE_ARM64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+      if [[ "$HAVE_ARM64_RPM" != "true" ]]; then
+        echo "Building on Linux arm64 because we have no RPM"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_ARM64_DEB" != "true" ]]; then
+        echo "Building on Linux arm64 because we have no DEB"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_ARM64_TAR" != "true" ]]; then
+        echo "Building on Linux arm64 because we have no TAR"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$SHOULD_BUILD" != "yes" ]]; then
+        echo "Already have all the Linux arm64 builds"
+      fi
     else
       HAVE_64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["x86_64.rpm"])')
       HAVE_64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["amd64.deb"])')

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/vscodium/vscodium/releases/tags/$LATEST_MS_TAG)
+GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/435vic/vscodium/releases/tags/$LATEST_MS_TAG)
 echo "Github response: ${GITHUB_RESPONSE}"
 VSCODIUM_ASSETS=$(echo $GITHUB_RESPONSE | jq '.assets')
 echo "VSCodium assets: ${VSCODIUM_ASSETS}"

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -7,6 +7,9 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   elif [[ "$BUILDARCH" == "ia32" ]]; then
     cd VSCode-linux-ia32
     tar czf ../VSCode-linux-ia32-${LATEST_MS_TAG}.tar.gz .
+  elif [[ "$BUILDARCH" == "arm64" ]]; then
+    cd VSCode-linux-arm64
+    tar czf ../VSCode-linux-arm64-${LATEST_MS_TAG}.tar.gz .
   else
     cd VSCode-linux-x64
     tar czf ../VSCode-linux-x64-${LATEST_MS_TAG}.tar.gz .

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,6 +5,10 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install yarn --without-node
   brew install jq zip
 else
+  # Use the default C / C++ compilers,
+  # because some makefiles default to CC:=gcc:
+  export CC=/usr/bin/cc
+  export CXX=/usr/bin/c++
   sudo apt-get update
   sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm
   if [[ "$BUILDARCH" == "ia32" ]]; then

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,10 +5,6 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install yarn --without-node
   brew install jq zip
 else
-  # Use the default C / C++ compilers,
-  # because some makefiles default to CC:=gcc:
-  export CC=/usr/bin/cc
-  export CXX=/usr/bin/c++
   sudo apt-get update
   sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm
   if [[ "$BUILDARCH" == "ia32" ]]; then
@@ -16,5 +12,10 @@ else
     sudo apt-get update
     sudo apt-get install libc6-dev-i386 gcc-multilib g++-multilib
     sudo apt-get install libx11-dev:i386 libxkbfile-dev:i386
+  elif [[ $BUILDARCH == "arm64" ]]; then
+    # Use the default C / C++ compilers,
+    # because some makefiles default to CC:=gcc:
+    export CC=/usr/bin/cc
+    export CXX=/usr/bin/c++
   fi
 fi


### PR DESCRIPTION
I have modified the files to build and deploy arm64 packages using Travis CI, which fixes issue #6.
However, the RPM builds for arm64 don't work for some reason, I think it's an error on the vscode rpm gulpfile...
```[22:42:09] Starting 'vscode-linux-arm64-prepare-rpm'...
[22:42:09] 'vscode-linux-arm64-prepare-rpm' errored after 12 ms
[22:42:09] TypeError: Cannot read property 'join' of undefined
    at Gulp.<anonymous> (/home/travis/build/435vic/vscodium/vscode/build/gulpfile.vscode.linux.js:151:63)
    at module.exports (/home/travis/build/435vic/vscodium/vscode/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/home/travis/build/435vic/vscodium/vscode/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/home/travis/build/435vic/vscodium/vscode/node_modules/orchestrator/index.js:214:10)
    at /home/travis/build/435vic/vscodium/vscode/node_modules/orchestrator/index.js:279:18
    at finish (/home/travis/build/435vic/vscodium/vscode/node_modules/orchestrator/lib/runTask.js:21:8)
    at cb (/home/travis/build/435vic/vscodium/vscode/node_modules/orchestrator/lib/runTask.js:29:3)
    at /home/travis/build/435vic/vscodium/vscode/build/lib/util.js:174:24
    at next (/home/travis/build/435vic/vscodium/vscode/node_modules/rimraf/rimraf.js:74:7)
    at CB (/home/travis/build/435vic/vscodium/vscode/node_modules/rimraf/rimraf.js:110:9)
```
The link for the file in the Vscode repository is [here](https://github.com/Microsoft/vscode/blob/797161bd324200dcaf1cf297998a92b84c70ea9d/build/gulpfile.vscode.linux.js#L151).

Other than that, the build went pretty smoothly, deploying both the `.tar.gz` and the `.deb` files.