### PR TITLE
Replace telemetry default true values in settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Microsoft's build process does download additional files. This was brought up in
   - ffmpeg
 
 ## <a id="disable-telemetry"></a>Getting all the Telemetry Out
-Even though we do not pass the telemetry build flags (and go out of our way to cripple the baked-in telemetry), Microsoft will still track usage by default. After installing VSCodium, you must manually disable telemetry in your settings file to stop it from sending tracking data to Microsoft. 
+Even though we do not pass the telemetry build flags (and go out of our way to cripple the baked-in telemetry), Microsoft will still track usage by default.
 
-The instructions [here](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting) and [here](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-crash-reporting) help with disabling telemetry. 
+We do however set the default `telemetry.enableCrashReporter` and `telemetry.enableTelemetry` values to false. You can see those by viewing your VSCodium settings.json and searching for `telemetry`.
+
+The instructions [here](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting) and [here](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-crash-reporting) help with explaining and toggling telemetry. 
 
 It is also highly recommended that you review all the settings that "use online services" by following [these instructions](https://code.visualstudio.com/docs/supporting/faq#_managing-online-services). The `@tag:usesOnlineServices` filter on the settings page will show that by default:
 - Extensions auto check for updates and auto install updates

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,6 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-linux-x64-build-rpm
   fi
 
-  ../update_settings.sh
-
   cd ..
+  ./update_settings.sh
 fi

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     export npm_config_arch=ia32
   fi
 
+  ../update_settings.sh
+
   yarn
   mv product.json product.json.bak
   cat product.json.bak | jq 'setpath(["extensionsGallery"]; {"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery", "cacheUrl": "https://vscode.blob.core.windows.net/gallery/index", "itemUrl": "https://marketplace.visualstudio.com/items"}) | setpath(["nameShort"]; "VSCodium") | setpath(["nameLong"]; "VSCodium") | setpath(["applicationName"]; "vscodium") | setpath(["win32MutexName"]; "vscodium") | setpath(["win32DirName"]; "VSCodium") | setpath(["win32NameVersion"]; "VSCodium") | setpath(["win32RegValueName"]; "VSCodium") | setpath(["win32AppUserModelId"]; "Microsoft.VSCodium") | setpath(["win32ShellNameShort"]; "V&SCodium") | setpath(["urlProtocol"]; "vscodium")' > product.json

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     export npm_config_arch=ia32
   fi
 
+  ../update_settings.sh
+
   yarn
   mv product.json product.json.bak
   cat product.json.bak | jq 'setpath(["extensionsGallery"]; {"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery", "cacheUrl": "https://vscode.blob.core.windows.net/gallery/index", "itemUrl": "https://marketplace.visualstudio.com/items"}) | setpath(["nameShort"]; "VSCodium") | setpath(["nameLong"]; "VSCodium") | setpath(["applicationName"]; "vscodium") | setpath(["win32MutexName"]; "vscodium") | setpath(["win32DirName"]; "VSCodium") | setpath(["win32NameVersion"]; "VSCodium") | setpath(["win32RegValueName"]; "VSCodium") | setpath(["win32AppUserModelId"]; "Microsoft.VSCodium") | setpath(["win32ShellNameShort"]; "V&SCodium") | setpath(["urlProtocol"]; "vscodium")' > product.json
@@ -40,7 +42,4 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-linux-x64-build-deb
     npm run gulp vscode-linux-x64-build-rpm
   fi
-
-  cd ..
-  ./update_settings.sh
 fi

--- a/build.sh
+++ b/build.sh
@@ -41,5 +41,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-linux-x64-build-rpm
   fi
 
+  ../update_settings.sh
+
   cd ..
 fi

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,6 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     export npm_config_arch=ia32
   fi
 
-  ../update_settings.sh
-
   yarn
   mv product.json product.json.bak
   cat product.json.bak | jq 'setpath(["extensionsGallery"]; {"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery", "cacheUrl": "https://vscode.blob.core.windows.net/gallery/index", "itemUrl": "https://marketplace.visualstudio.com/items"}) | setpath(["nameShort"]; "VSCodium") | setpath(["nameLong"]; "VSCodium") | setpath(["applicationName"]; "vscodium") | setpath(["win32MutexName"]; "vscodium") | setpath(["win32DirName"]; "VSCodium") | setpath(["win32NameVersion"]; "VSCodium") | setpath(["win32RegValueName"]; "VSCodium") | setpath(["win32AppUserModelId"]; "Microsoft.VSCodium") | setpath(["win32ShellNameShort"]; "V&SCodium") | setpath(["urlProtocol"]; "vscodium")' > product.json

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -6,8 +6,8 @@ REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 TELEMETRY_CRASH_REPORTER="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:!0"
 TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:!0"
 
-TELEMETRY_CRASH_REPORTER_REPLACEMENT="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:false"
-TELEMETRY_ENABLE_REPLACEMENT="\{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:false"
+TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:false/g"
+TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/\{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:false/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -3,11 +3,11 @@
 TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
 REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
-TELEMETRY_CRASH_REPORTER="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
 TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
 
-TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/\{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -3,9 +3,19 @@
 TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
 REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
+TELEMETRY_CRASH_REPORTER="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:!0"
+TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:!0"
+
+TELEMETRY_CRASH_REPORTER_REPLACEMENT="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:false"
+TELEMETRY_ENABLE_REPLACEMENT="\{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:false"
+
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
 fi
 

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -5,10 +5,13 @@ REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
+  # set defaults for telemetry reporting to false
+  sed -i '' -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i '' -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
+  # set defaults for telemetry reporting to false
+  sed -i -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
 fi
 
-# set defaults for telemetry reporting to false
-sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -3,19 +3,19 @@
 TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
 REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
-TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
-TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+# TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+# TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
 
-TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+# TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+# TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
+  # grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  # grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
+  # grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  # grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
 fi
 

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -6,12 +6,12 @@ REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
   # set defaults for telemetry reporting to false
-  sed -i '' -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-  sed -i '' -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
   # set defaults for telemetry reporting to false
-  sed -i -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-  sed -i -E "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
 fi
 

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -5,13 +5,7 @@ REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
-  # set defaults for telemetry reporting to false
-  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
-  # set defaults for telemetry reporting to false
-  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
 fi
 

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -3,19 +3,19 @@
 TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
 REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
-TELEMETRY_CRASH_REPORTER="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:!0"
-TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:!0"
+TELEMETRY_CRASH_REPORTER="\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
 
-TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize(1,null),default:false/g"
-TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/\{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize(1,null),default:false/g"
+TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/\{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/\{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
 fi
 

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -3,19 +3,8 @@
 TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
 REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
-# TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
-# TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
-
-# TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-# TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i '' -E $REPLACEMENT
-  # grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  # grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
-  # grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  # grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
 fi
-

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -8,3 +8,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 else
   grep -rl --exclude-dir=.git -E $TELEMETRY_URLS . | xargs sed -i -E $REPLACEMENT
 fi
+
+# set defaults for telemetry reporting to false
+sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -1,8 +1,0 @@
-# set defaults for telemetry reporting to false
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
-else
-  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
-fi

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -1,0 +1,8 @@
+# set defaults for telemetry reporting to false
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i '' "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+else
+  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+fi

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -1,0 +1,13 @@
+TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+
+TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
+else
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
+fi

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -1,17 +1,9 @@
-# TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
-# TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+REPLACEMENT="s/'default': true/'default': false/"
 
-# TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-# TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-
-# if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-#   grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-#   grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
-# else
-#   grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-#   grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
-# fi
-
-# set defaults for telemetry reporting to false
-sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
-sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  sed -i '' -E "$REPLACEMENT" src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i '' -E "$REPLACEMENT" src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+else
+  sed -i -E "$REPLACEMENT" src/vs/platform/telemetry/common/telemetryService.ts
+  sed -i -E "$REPLACEMENT" src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+fi

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -5,9 +5,9 @@ TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.e
 TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
 else
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
 fi

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -1,13 +1,17 @@
-TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
-TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+# TELEMETRY_CRASH_REPORTER="{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
+# TELEMETRY_ENABLE="{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:\!0"
 
-TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
-TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+# TELEMETRY_CRASH_REPORTER_REPLACEMENT="s/$TELEMETRY_CRASH_REPORTER/{\"telemetry.enableCrashReporter\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
+# TELEMETRY_ENABLE_REPLACEMENT="s/$TELEMETRY_ENABLE/{\"telemetry.enableTelemetry\":{type:\"boolean\",description:n.localize\(1,null\),default:0/g"
 
-if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
-else
-  grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER . | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
-  grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE . | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
-fi
+# if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+#   grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i '' -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+#   grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i '' -E $TELEMETRY_ENABLE_REPLACEMENT
+# else
+#   grep -rl --exclude-dir=.git -E $TELEMETRY_CRASH_REPORTER ../ | xargs sed -i -E $TELEMETRY_CRASH_REPORTER_REPLACEMENT
+#   grep -rl --exclude-dir=.git -E $TELEMETRY_ENABLE ../ | xargs sed -i -E $TELEMETRY_ENABLE_REPLACEMENT
+# fi
+
+# set defaults for telemetry reporting to false
+sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/platform/telemetry/common/telemetryService.ts
+sed -i "s/\'default\': true,/\'default\': false,/g" ./src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts


### PR DESCRIPTION
This addresses Issue #44 by setting the default `telemetry.enableCrashReporter` and `telemetry.enableTelemetry` values to false in the undo_telemetry post install script.