### PR TITLE
Add script to trigger Azure pipelines build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 
 script:
   - ./build.sh
+  - ./trigger-azure.sh
 
 before_deploy:
   - ./create_zip.sh

--- a/trigger-azure.sh
+++ b/trigger-azure.sh
@@ -1,0 +1,7 @@
+if [ "$AZURE_TOKEN" != "" ]; then
+  if [[ "$SHOULD_BUILD" == "yes" ]]; then
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      curl -X POST -H "Content-Type: application/json" -H "Authorization: Basic $AZURE_TOKEN" -d '{"definition":{"id":1}}' https://dev.azure.com/VSCodium/vscodium/_apis/build/builds?api-version=5.0-preview.5
+    fi
+  fi
+fi


### PR DESCRIPTION
Have it set to only trigger from Mac build, and only if we actually built (and Azure token is present), which should stop us from queueing up more than build per Travis batch.

Tested locally that the curl command does in fact queue up an Azure build.

Closes #68