### PR TITLE
Build cleanup and Windows ia32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - os: linux
       sudo: required
-      env: BUILDARCH=amd64
+      env: BUILDARCH=x64
     - os: linux
       sudo: required
       env: BUILDARCH=ia32

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ matrix:
   include:
     - os: linux
       sudo: required
+      env: BUILDARCH=amd64
     - os: linux
       sudo: required
       env: BUILDARCH=ia32

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,3 +60,21 @@ steps:
   inputs:
     PathtoPublish: 'VSCodium-win32-x64-$(LATEST_MS_TAG).zip'
     ArtifactName: 'archive'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: 32-bit system-setup'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodiumSetup-ia32-$(LATEST_MS_TAG).exe'
+    ArtifactName: 'system_setup'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: 32-bit user-setup'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodiumUserSetup-ia32-$(LATEST_MS_TAG).exe'
+    ArtifactName: 'user_setup'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: 32-bit archive'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodium-win32-ia32-$(LATEST_MS_TAG).zip'
+    ArtifactName: 'archive'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,80 +1,16 @@
-pool:
-  vmImage: 'vs2017-win2016'
+jobs:
+- job: Windows
+  pool:
+    vmImage: VS2017-Win2016
+  variables:
+    BUILDARCH: x64
+  steps:
+  - template: win32-build.yml
 
-steps:
-- task: NodeTool@0 
-  inputs:
-    versionSpec: '8.x'
-- script: |
-    choco install jq 
-  displayName: 'install jq from choco'
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
-  displayName: 'Install Yarn'
-- task: UsePythonVersion@0
-  displayName: 'Use Python 2.x'
-  inputs:
-    versionSpec: 2.x
-- task: ShellScript@2
-  displayName: 'get VSCode sources'
-  inputs: 
-    scriptPath: get_repo.sh
-- powershell: |
-    $LATEST_MS_TAG="$(git -C vscode describe --tags)"
-    Write-Host "##vso[task.setvariable variable=LATEST_MS_TAG]$LATEST_MS_TAG"
-  displayName: 'set env LATEST_MS_TAG'
-- task: PowerShell@2
-  inputs:
-    filePath: 'check_tags.ps1'
-  env:
-    MAPPED_GITHUB_TOKEN: $(GITHUB_TOKEN)
-- script: |
-    git -C vscode status
-  displayName: 'vscode status'
-- powershell: |
-    bash ./build.sh
-  displayName: 'go build it!'
-- bash: |
-    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\system-setup\\VSCodeSetup.exe VSCodiumSetup-x64-${LATEST_MS_TAG}.exe; fi
-  displayName: 'move the system setup'
-- bash: |
-    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\user-setup\\VSCodeSetup.exe VSCodiumUserSetup-x64-${LATEST_MS_TAG}.exe; fi
-  displayName: 'move the user setup'
-- bash: |
-    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\archive\\VSCode-win32-x64.zip VSCodium-win32-x64-${LATEST_MS_TAG}.zip; fi
-  displayName: 'move the zip folder'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: system-setup'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodiumSetup-x64-$(LATEST_MS_TAG).exe'
-    ArtifactName: 'system_setup'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: user-setup'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodiumUserSetup-x64-$(LATEST_MS_TAG).exe'
-    ArtifactName: 'user_setup'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: archive'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodium-win32-x64-$(LATEST_MS_TAG).zip'
-    ArtifactName: 'archive'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: 32-bit system-setup'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodiumSetup-ia32-$(LATEST_MS_TAG).exe'
-    ArtifactName: 'system_setup'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: 32-bit user-setup'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodiumUserSetup-ia32-$(LATEST_MS_TAG).exe'
-    ArtifactName: 'user_setup'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: 32-bit archive'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodium-win32-ia32-$(LATEST_MS_TAG).zip'
-    ArtifactName: 'archive'
+- job: Windows32
+  pool:
+    vmImage: VS2017-Win2016
+  variables:
+    BUILDARCH: ia32
+  steps:
+  - template: win32-build.yml

--- a/build.sh
+++ b/build.sh
@@ -50,11 +50,14 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-win32-x64-archive
 
     # 32-bit windows builds
-    rm -rf node_modules
+    cd ..
+    rm -rf vscode
+    ./get_repo.sh
+    cd vscode
     export npm_config_arch=ia32
     export npm_config_target_arch=ia32
-    yarn # force rebuild of native packages
-    ../undo_telemetry.sh # re undo telemetry for any deps that have it
+    yarn
+    ../undo_telemetry.sh
 
     npm run gulp vscode-win32-ia32-min
     npm run gulp vscode-win32-ia32-inno-updater

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,12 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-win32-x64-system-setup
     npm run gulp vscode-win32-x64-user-setup
     npm run gulp vscode-win32-x64-archive
+    # 32-bit windows builds
+    npm run gulp vscode-win32-ia32-min
+    npm run gulp vscode-win32-ia32-inno-updater
+    npm run gulp vscode-win32-ia32-system-setup
+    npm run gulp vscode-win32-ia32-user-setup
+    npm run gulp vscode-win32-ia32-archive
   else
     npm run gulp vscode-linux-x64-min
     npm run gulp vscode-linux-x64-build-deb

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,13 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-win32-x64-system-setup
     npm run gulp vscode-win32-x64-user-setup
     npm run gulp vscode-win32-x64-archive
+
     # 32-bit windows builds
+    export npm_config_arch=ia32
+    export npm_config_target_arch=ia32
+    yarn --force # force rebuild of native packages
+    ../undo_telemetry.sh # re undo telemetry for any deps that have it
+
     npm run gulp vscode-win32-ia32-min
     npm run gulp vscode-win32-ia32-inno-updater
     npm run gulp vscode-win32-ia32-system-setup

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   cd vscode
 
   export npm_config_arch="$BUILDARCH"
-  export npm_config_target_arch=arm64
+  export npm_config_target_arch="$BUILDARCH"
   ../update_settings.sh
 
   yarn
@@ -27,15 +27,15 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp -- "vscode-darwin-min"
   elif [[ "$CI_WINDOWS" == "True" ]]; then
     cp LICENSE.txt LICENSE.rtf # windows build expects rtf license
-    npm run gulp -- "vscode-win32-$(BUILDARCH)-min"
-    npm run gulp -- "vscode-win32-$(BUILDARCH)-inno-updater"
-    npm run gulp -- "vscode-win32-$(BUILDARCH)-system-setup"
-    npm run gulp -- "vscode-win32-$(BUILDARCH)-user-setup"
-    npm run gulp -- "vscode-win32-$(BUILDARCH)-archive"
+    npm run gulp -- "vscode-win32-${BUILDARCH}-min"
+    npm run gulp -- "vscode-win32-${BUILDARCH}-inno-updater"
+    npm run gulp -- "vscode-win32-${BUILDARCH}-system-setup"
+    npm run gulp -- "vscode-win32-${BUILDARCH}-user-setup"
+    npm run gulp -- "vscode-win32-${BUILDARCH}-archive"
   else # linux
-    npm run gulp -- "vscode-linux-$(BUILDARCH)-min"
-    npm run gulp -- "vscode-linux-$(BUILDARCH)-build-deb"
-    npm run gulp -- "vscode-linux-$(BUILDARCH)-build-rpm"
+    npm run gulp -- "vscode-linux-${BUILDARCH}-min"
+    npm run gulp -- "vscode-linux-${BUILDARCH}-build-deb"
+    npm run gulp -- "vscode-linux-${BUILDARCH}-build-rpm"
   fi  
 
   cd ..

--- a/build.sh
+++ b/build.sh
@@ -3,15 +3,8 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   cp -rp src/* vscode/
   cd vscode
 
-  if [[ "$BUILDARCH" == "ia32" ]]; then
-    export npm_config_arch=ia32
-    export npm_config_target_arch=ia32
-  fi
-
-  if [[ "$BUILDARCH" == "arm64" ]]; then
-    export npm_config_arch=arm64
-    export npm_config_target_arch=arm64
-  fi
+  export npm_config_arch="$BUILDARCH"
+  export npm_config_target_arch=arm64
   ../update_settings.sh
 
   yarn
@@ -28,46 +21,21 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     # as we are renaming the application to vscodium
     # we need to edit a line in the post install template
     sed -i "s/code-oss/vscodium/" resources/linux/debian/postinst.template
-    fi
+  fi
 
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    npm run gulp vscode-darwin-min
-  elif [[ "$BUILDARCH" == "ia32" ]]; then
-      npm run gulp vscode-linux-ia32-min
-      npm run gulp vscode-linux-ia32-build-deb
-      npm run gulp vscode-linux-ia32-build-rpm
-      unset npm_config_arch
-  elif [[ "$BUILDARCH" == "arm64" ]]; then
-    npm run gulp vscode-linux-arm64-min
-    npm run gulp vscode-linux-arm64-build-deb
-    # npm run gulp vscode-linux-arm64-build-rpm
+    npm run gulp -- "vscode-darwin-min"
   elif [[ "$CI_WINDOWS" == "True" ]]; then
     cp LICENSE.txt LICENSE.rtf # windows build expects rtf license
-    npm run gulp vscode-win32-x64-min
-    npm run gulp vscode-win32-x64-inno-updater
-    npm run gulp vscode-win32-x64-system-setup
-    npm run gulp vscode-win32-x64-user-setup
-    npm run gulp vscode-win32-x64-archive
-
-    # 32-bit windows builds
-    cd ..
-    rm -rf vscode
-    ./get_repo.sh
-    cd vscode
-    export npm_config_arch=ia32
-    export npm_config_target_arch=ia32
-    yarn
-    ../undo_telemetry.sh
-
-    npm run gulp vscode-win32-ia32-min
-    npm run gulp vscode-win32-ia32-inno-updater
-    npm run gulp vscode-win32-ia32-system-setup
-    npm run gulp vscode-win32-ia32-user-setup
-    npm run gulp vscode-win32-ia32-archive
-  else
-    npm run gulp vscode-linux-x64-min
-    npm run gulp vscode-linux-x64-build-deb
-    npm run gulp vscode-linux-x64-build-rpm
+    npm run gulp -- "vscode-win32-$(BUILDARCH)-min"
+    npm run gulp -- "vscode-win32-$(BUILDARCH)-inno-updater"
+    npm run gulp -- "vscode-win32-$(BUILDARCH)-system-setup"
+    npm run gulp -- "vscode-win32-$(BUILDARCH)-user-setup"
+    npm run gulp -- "vscode-win32-$(BUILDARCH)-archive"
+  else # linux
+    npm run gulp -- "vscode-linux-$(BUILDARCH)-min"
+    npm run gulp -- "vscode-linux-$(BUILDARCH)-build-deb"
+    npm run gulp -- "vscode-linux-$(BUILDARCH)-build-rpm"
   fi  
 
   cd ..

--- a/build.sh
+++ b/build.sh
@@ -50,9 +50,10 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     npm run gulp vscode-win32-x64-archive
 
     # 32-bit windows builds
+    rm -rf node_modules
     export npm_config_arch=ia32
     export npm_config_target_arch=ia32
-    yarn --force # force rebuild of native packages
+    yarn # force rebuild of native packages
     ../undo_telemetry.sh # re undo telemetry for any deps that have it
 
     npm run gulp vscode-win32-ia32-min

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -1,6 +1,8 @@
 echo "tag: $env:LATEST_MS_TAG"
 $REPO_URI = [uri]$env:BUILD_REPOSITORY_URI
-$USER_REPO = $REPO_URI.LocalPath
+$REPO_URI
+$USER_REPO = $REPO_URI."LocalPath"
+echo $USER_REPO
 $GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/$USER_REPO/releases/tags/$env:LATEST_MS_TAG"
 echo "Github response: ${GITHUB_RESPONSE}"
 $VSCODIUM_ASSETS= $GITHUB_RESPONSE | jq '.assets'

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -1,4 +1,5 @@
 echo "tag: $env:LATEST_MS_TAG"
+echo $env:Build.Repository.Uri
 $GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/vscodium/vscodium/releases/tags/$env:LATEST_MS_TAG"
 echo "Github response: ${GITHUB_RESPONSE}"
 $VSCODIUM_ASSETS= $GITHUB_RESPONSE | jq '.assets'

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -2,7 +2,7 @@ echo "tag: $env:LATEST_MS_TAG"
 $REPO_URI = [uri]$env:BUILD_REPOSITORY_URI
 $USER_REPO = $REPO_URI."LocalPath"
 echo $USER_REPO
-$GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/$USER_REPO/releases/tags/$env:LATEST_MS_TAG"
+$GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos$USER_REPO/releases/tags/$env:LATEST_MS_TAG"
 echo "Github response: ${GITHUB_RESPONSE}"
 $VSCODIUM_ASSETS = $GITHUB_RESPONSE | jq '.assets'
 echo "VSCodium assets: ${VSCODIUM_ASSETS}"

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -1,5 +1,6 @@
 echo "tag: $env:LATEST_MS_TAG"
-echo $env:Build.Repository.Uri
+echo $env:BUILD_REPOSITORY_URI
+echo "Getting GH assets"
 $GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/vscodium/vscodium/releases/tags/$env:LATEST_MS_TAG"
 echo "Github response: ${GITHUB_RESPONSE}"
 $VSCODIUM_ASSETS= $GITHUB_RESPONSE | jq '.assets'

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -1,7 +1,7 @@
 echo "tag: $env:LATEST_MS_TAG"
-echo $env:BUILD_REPOSITORY_URI
-echo "Getting GH assets"
-$GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/vscodium/vscodium/releases/tags/$env:LATEST_MS_TAG"
+$REPO_URI = [uri]$env:BUILD_REPOSITORY_URI
+$USER_REPO = $REPO_URI.LocalPath
+$GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/$USER_REPO/releases/tags/$env:LATEST_MS_TAG"
 echo "Github response: ${GITHUB_RESPONSE}"
 $VSCODIUM_ASSETS= $GITHUB_RESPONSE | jq '.assets'
 echo "VSCodium assets: ${VSCODIUM_ASSETS}"

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -1,6 +1,5 @@
 echo "tag: $env:LATEST_MS_TAG"
 $REPO_URI = [uri]$env:BUILD_REPOSITORY_URI
-$REPO_URI
 $USER_REPO = $REPO_URI."LocalPath"
 echo $USER_REPO
 $GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/$USER_REPO/releases/tags/$env:LATEST_MS_TAG"
@@ -18,21 +17,22 @@ if (!$env:MAPPED_GITHUB_TOKEN -or $env:MAPPED_GITHUB_TOKEN -like "*GITHUB_TOKEN*
 if (!$VSCODIUM_ASSETS) {
   echo "Release assets do not exist at all, continuing build"
   $SHOULD_BUILD = 'yes'
+} else {
+  $WindowsAssets = ($VSCODIUM_ASSETS | ConvertFrom-Json) | Where-Object { $_.name.Contains('exe') }
+  $SYSTEM_SETUP = $WindowsAssets | Where-Object { $_.name.Contains('Setup') }
+  $USER_SETUP = $WindowsAssets | Where-Object { $_.name.Contains('User') }
+  if (!$SYSTEM_SETUP) {
+    echo "Building on Windows because we have no system-setup.exe";
+    $SHOULD_BUILD = 'yes'
+  }
+  elseif (!$USER_SETUP) {
+    echo "Building on Windows because we have no user-setup.exe";
+    $SHOULD_BUILD = 'yes'
+  }
+  else {
+    echo "Already have all the Windows builds"
+  } 
 }
 
-$WindowsAssets = ($VSCODIUM_ASSETS | ConvertFrom-Json) | Where-Object { $_.name.Contains('exe') }
-$SYSTEM_SETUP = $WindowsAssets | Where-Object { $_.name.Contains('Setup') }
-$USER_SETUP = $WindowsAssets | Where-Object { $_.name.Contains('User') }
-if (!$SYSTEM_SETUP) {
-  echo "Building on Windows because we have no system-setup.exe";
-  $SHOULD_BUILD = 'yes'
-}
-elseif (!$USER_SETUP) {
-  echo "Building on Windows because we have no user-setup.exe";
-  $SHOULD_BUILD = 'yes'
-}
-else {
-  echo "Already have all the Windows builds"
-}
 
 Write-Host "##vso[task.setvariable variable=SHOULD_BUILD]$SHOULD_BUILD"

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -4,7 +4,7 @@ $USER_REPO = $REPO_URI."LocalPath"
 echo $USER_REPO
 $GITHUB_RESPONSE = curl.exe -s -H "Authorization: token $env:MAPPED_GITHUB_TOKEN" "https://api.github.com/repos/$USER_REPO/releases/tags/$env:LATEST_MS_TAG"
 echo "Github response: ${GITHUB_RESPONSE}"
-$VSCODIUM_ASSETS= $GITHUB_RESPONSE | jq '.assets'
+$VSCODIUM_ASSETS = $GITHUB_RESPONSE | jq '.assets'
 echo "VSCodium assets: ${VSCODIUM_ASSETS}"
 
 # if we just don't have the github token, get out fast
@@ -14,7 +14,7 @@ if (!$env:MAPPED_GITHUB_TOKEN -or $env:MAPPED_GITHUB_TOKEN -like "*GITHUB_TOKEN*
   return
 }
 
-if (!$VSCODIUM_ASSETS) {
+if ($VSCODIUM_ASSETS -eq "null" || !$VSCODIUM_ASSETS || $VSCODIUM_ASSETS -eq $null) {
   echo "Release assets do not exist at all, continuing build"
   $SHOULD_BUILD = 'yes'
 } else {

--- a/check_tags.ps1
+++ b/check_tags.ps1
@@ -14,7 +14,7 @@ if (!$env:MAPPED_GITHUB_TOKEN -or $env:MAPPED_GITHUB_TOKEN -like "*GITHUB_TOKEN*
   return
 }
 
-if ($VSCODIUM_ASSETS -eq "null" || !$VSCODIUM_ASSETS || $VSCODIUM_ASSETS -eq $null) {
+if ($VSCODIUM_ASSETS -eq "null" -or !$VSCODIUM_ASSETS) {
   echo "Release assets do not exist at all, continuing build"
   $SHOULD_BUILD = 'yes'
 } else {

--- a/win32-build.yml
+++ b/win32-build.yml
@@ -31,47 +31,29 @@ steps:
     bash ./build.sh
   displayName: 'go build it!'
 - bash: |
-    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\system-setup\\VSCodeSetup.exe VSCodiumSetup-x64-${LATEST_MS_TAG}.exe; fi
+    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-$(BUILDARCH)\\system-setup\\VSCodeSetup.exe VSCodiumSetup-$(BUILDARCH)-${LATEST_MS_TAG}.exe; fi
   displayName: 'move the system setup'
 - bash: |
-    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\user-setup\\VSCodeSetup.exe VSCodiumUserSetup-x64-${LATEST_MS_TAG}.exe; fi
+    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-$(BUILDARCH)\\user-setup\\VSCodeSetup.exe VSCodiumUserSetup-$(BUILDARCH)-${LATEST_MS_TAG}.exe; fi
   displayName: 'move the user setup'
 - bash: |
-    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\archive\\VSCode-win32-x64.zip VSCodium-win32-x64-${LATEST_MS_TAG}.zip; fi
+    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-$(BUILDARCH)\\archive\\VSCode-win32-$(BUILDARCH).zip VSCodium-win32-$(BUILDARCH)-${LATEST_MS_TAG}.zip; fi
   displayName: 'move the zip folder'
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts: system-setup'
   condition: eq(variables['SHOULD_BUILD'], 'yes')
   inputs:
-    PathtoPublish: 'VSCodiumSetup-x64-$(LATEST_MS_TAG).exe'
+    PathtoPublish: 'VSCodiumSetup-$(BUILDARCH)-$(LATEST_MS_TAG).exe'
     ArtifactName: 'system_setup'
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts: user-setup'
   condition: eq(variables['SHOULD_BUILD'], 'yes')
   inputs:
-    PathtoPublish: 'VSCodiumUserSetup-x64-$(LATEST_MS_TAG).exe'
+    PathtoPublish: 'VSCodiumUserSetup-$(BUILDARCH)-$(LATEST_MS_TAG).exe'
     ArtifactName: 'user_setup'
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts: archive'
   condition: eq(variables['SHOULD_BUILD'], 'yes')
   inputs:
-    PathtoPublish: 'VSCodium-win32-x64-$(LATEST_MS_TAG).zip'
-    ArtifactName: 'archive'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: 32-bit system-setup'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodiumSetup-ia32-$(LATEST_MS_TAG).exe'
-    ArtifactName: 'system_setup'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: 32-bit user-setup'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodiumUserSetup-ia32-$(LATEST_MS_TAG).exe'
-    ArtifactName: 'user_setup'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: 32-bit archive'
-  condition: eq(variables['SHOULD_BUILD'], 'yes')
-  inputs:
-    PathtoPublish: 'VSCodium-win32-ia32-$(LATEST_MS_TAG).zip'
+    PathtoPublish: 'VSCodium-win32-$(BUILDARCH)-$(LATEST_MS_TAG).zip'
     ArtifactName: 'archive'

--- a/win32-build.yml
+++ b/win32-build.yml
@@ -1,0 +1,77 @@
+steps:
+- task: NodeTool@0 
+  inputs:
+    versionSpec: '8.x'
+- script: |
+    choco install jq 
+  displayName: 'install jq from choco'
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+  displayName: 'Install Yarn'
+- task: UsePythonVersion@0
+  displayName: 'Use Python 2.x'
+  inputs:
+    versionSpec: 2.x
+- task: ShellScript@2
+  displayName: 'get VSCode sources'
+  inputs: 
+    scriptPath: get_repo.sh
+- powershell: |
+    $LATEST_MS_TAG="$(git -C vscode describe --tags)"
+    Write-Host "##vso[task.setvariable variable=LATEST_MS_TAG]$LATEST_MS_TAG"
+  displayName: 'set env LATEST_MS_TAG'
+- task: PowerShell@2
+  inputs:
+    filePath: 'check_tags.ps1'
+  env:
+    MAPPED_GITHUB_TOKEN: $(GITHUB_TOKEN)
+- script: |
+    git -C vscode status
+  displayName: 'vscode status'
+- powershell: |
+    bash ./build.sh
+  displayName: 'go build it!'
+- bash: |
+    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\system-setup\\VSCodeSetup.exe VSCodiumSetup-x64-${LATEST_MS_TAG}.exe; fi
+  displayName: 'move the system setup'
+- bash: |
+    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\user-setup\\VSCodeSetup.exe VSCodiumUserSetup-x64-${LATEST_MS_TAG}.exe; fi
+  displayName: 'move the user setup'
+- bash: |
+    if [[ "$SHOULD_BUILD" == "yes" ]]; then mv vscode\\.build\\win32-x64\\archive\\VSCode-win32-x64.zip VSCodium-win32-x64-${LATEST_MS_TAG}.zip; fi
+  displayName: 'move the zip folder'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: system-setup'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodiumSetup-x64-$(LATEST_MS_TAG).exe'
+    ArtifactName: 'system_setup'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: user-setup'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodiumUserSetup-x64-$(LATEST_MS_TAG).exe'
+    ArtifactName: 'user_setup'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: archive'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodium-win32-x64-$(LATEST_MS_TAG).zip'
+    ArtifactName: 'archive'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: 32-bit system-setup'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodiumSetup-ia32-$(LATEST_MS_TAG).exe'
+    ArtifactName: 'system_setup'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: 32-bit user-setup'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodiumUserSetup-ia32-$(LATEST_MS_TAG).exe'
+    ArtifactName: 'user_setup'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: 32-bit archive'
+  condition: eq(variables['SHOULD_BUILD'], 'yes')
+  inputs:
+    PathtoPublish: 'VSCodium-win32-ia32-$(LATEST_MS_TAG).zip'
+    ArtifactName: 'archive'


### PR DESCRIPTION
Made `build.sh` easier to reason about and setup pipeline for building Windows 32-bit binaries. The binaries haven't been tested on 32-bit machines but the build process went smoothly.