### PR TITLE
Update check for Mac artifact

### DIFF
--- a/check_tags.sh
+++ b/check_tags.sh
@@ -10,7 +10,7 @@ echo "VSCodium assets: ${VSCODIUM_ASSETS}"
 if [ "$GITHUB_TOKEN" != "" ]; then
   if [ "$VSCODIUM_ASSETS" != "null" ]; then
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["zip"])')
+      HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq --arg suffix "darwin-$LATEST_MS_TAG.zip" 'map(.name) | contains([$suffix])')
       if [[ "$HAVE_MAC" != "true" ]]; then
         echo "Building on Mac because we have no ZIP"
         export SHOULD_BUILD="yes"


### PR DESCRIPTION
The current check collides with the Windows zip file, so a race condition could exist where a Windows build finishes before a Mac build checks if it should build.