### PR TITLE
Launch the IDE with codium (instead of vscodium)

### DIFF
--- a/VSCodium-AppImage-Recipe.yml
+++ b/VSCodium-AppImage-Recipe.yml
@@ -12,7 +12,7 @@ ingredients:
     - code
     - libgconf2-4
   dist: trusty
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   script:
     - pwd
@@ -32,4 +32,4 @@ script:
   - convert vscodium.png -resize 32x32 usr/share/icons/hicolor/32x32/apps/vscodium.png
   - convert vscodium.png -resize 24x24 usr/share/icons/hicolor/24x24/apps/vscodium.png
   - convert vscodium.png -resize 22x22 usr/share/icons/hicolor/22x22/apps/vscodium.png
-  - ( cd usr/bin/ ; ln -s ../share/vscodium/vscodium  . )
+  - ( cd usr/bin/ ; ln -s ../share/vscodium/codium  . )

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   extensionsGallery='setpath(["extensionsGallery"]; {"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery", "cacheUrl": "https://vscode.blob.core.windows.net/gallery/index", "itemUrl": "https://marketplace.visualstudio.com/items"})'
   nameShort='setpath(["nameShort"]; "VSCodium")'
   nameLong='setpath(["nameLong"]; "VSCodium")'
-  applicationName='setpath(["applicationName"]; "vscodium")'
+  applicationName='setpath(["applicationName"]; "codium")'
   win32MutexName='setpath(["win32MutexName"]; "vscodium")'
   win32DirName='setpath(["win32DirName"]; "VSCodium")'
   win32NameVersion='setpath(["win32NameVersion"]; "VSCodium")'


### PR DESCRIPTION
We want to run VSCodium via `codium` in the terminal. This aligns with the non-free binary distribution and should make transitioning easier w.r.t. muscle memory.

Fixes #36.