### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For more information on getting all the telemetry disabled and tips for migratin
 ### Extension Licensing
 Please note that some Visual Studio Code extensions have licenses that restrict their use to the official Visual Studio Code builds and therefore do not work with VSCodium. See [this note](https://github.com/VSCodium/vscodium/blob/master/DOCS.md#proprietary-debugging-tools) on the Docs page for what's been found so far and possible workarounds.
 
-### How do are the VSCodium binaries built?
+### How are the VSCodium binaries built?
 If you would like to see the commands we run to build `vscode` into VSCodium binaries, have a look at the [`.travis.yml` file](https://github.com/VSCodium/vscodium/blob/master/.travis.yml) (for Linux and OS X builds) and the [`win32-build.yml` file](https://github.com/VSCodium/vscodium/blob/master/win32-build.yml) (for Windows builds). These build files call all the other scripts in the repo. If you find something that doesn't make sense, feel free to ask about it [on Gitter](https://gitter.im/VSCodium/Lobby).
 
 The builds are run every day, but exit early if there isn't a new release from Microsoft. To examine the build logs, go [here for Linux / OS X](https://travis-ci.com/VSCodium/vscodium) and [here for Windows](https://dev.azure.com/vscodium/VSCodium/_build?definitionId=1)


### PR DESCRIPTION
- Minor typo

**Also:**
The GitHub description is: `binary releases of VS Code without MS branding/telemetry/licensing` Maybe we can upcase the leading `B` of `binary`