### PR TITLE
Fix hash paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ matrix:
     - os: linux
       sudo: required
       env: BUILDARCH=x64
-# arm64 builds don't work yet
-#    - os: linux
-#      sudo: required
-#      env: BUILDARCH=arm64
     - os: osx
 
 language: node_js
@@ -41,12 +37,9 @@ deploy:
     - ./*.zip
     - ./*.tar.gz
     - ./*.dmg
-    - vscode/.build/linux/deb/i386/deb/*.deb
-    - vscode/.build/linux/rpm/i386/*.rpm
-    - vscode/.build/linux/deb/amd64/deb/*.deb
-    - vscode/.build/linux/rpm/x86_64/*.rpm
-    - vscode/.build/linux/deb/arm64/deb/*.deb
-    - vscode/out/*.AppImage
+    - ./*.deb
+    - ./*.rpm
+    - ./*.AppImage
   on:
     all_branches: true
     condition: $SHOULD_BUILD = yes

--- a/sum.sh
+++ b/sum.sh
@@ -27,13 +27,13 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     sum_file VSCodiumUserSetup-*.exe
     sum_file VSCodium-win32-*.zip
   else # linux
-    sum_file vscode/out/*.AppImage
-    sum_file VSCodium-linux*.tar.gz
-    sum_file vscode/.build/linux/deb/amd64/deb/*.deb
-    sum_file vscode/.build/linux/rpm/x86_64/*.rpm
+    cp vscode/out/*.AppImage .
+    cp vscode/.build/linux/deb/amd64/deb/*.deb .
+    cp vscode/.build/linux/rpm/x86_64/*.rpm .
 
-    cp vscode/out/*.{sha256,sha1} .
-    cp vscode/.build/linux/deb/amd64/deb/*.{sha256,sha1} .
-    cp vscode/.build/linux/rpm/x86_64/*.{sha256,sha1} .
+    sum_file *.AppImage
+    sum_file VSCodium-linux*.tar.gz
+    sum_file *.deb
+    sum_file *.rpm
   fi
 fi


### PR DESCRIPTION
Closes #232 

Copy assets to root before summing.

Result (from my fork):

```
$ curl -L https://github.com/stripedpajamas/vscodium/releases/download/1.36.1/codium-1.36.1-1564071921.el7.x86_64.rpm.sha256
da65e074afed969ab9958650c1f250773ba99e718a9704c70d3311dfb4be8355  codium-1.36.1-1564071921.el7.x86_64.rpm

$ curl -L https://github.com/stripedpajamas/vscodium/releases/download/1.36.1/codium_1.36.1-1564071755_amd64.deb.sha256
474e584a295b672ba916e6a285cb097bcc768b093fb625c1a69d11796de0be9a  codium_1.36.1-1564071755_amd64.deb

$ curl -L https://github.com/stripedpajamas/vscodium/releases/download/1.36.1/VSCodium-1.36.1-1564071755.glibc2.16-x86_64.AppImage.sha256
27e56620a51e63a843a117c9850f0d2c6a474d8ebf5a43ecbc4d7fc3669f8fb7  VSCodium-1.36.1-1564071755.glibc2.16-x86_64.AppImage

$ curl -L https://github.com/stripedpajamas/vscodium/releases/download/1.36.1/VSCodium-linux-x64-1.36.1.tar.gz.sha256
d40273f96a0f7df4aa3f8a851d08d16e34fa4cd30c5e1e559b754eb1794a04e5  VSCodium-linux-x64-1.36.1.tar.gz
```