### PR TITLE
Update build process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+function keep_alive() {
+  while true; do
+    date
+    sleep 60
+  done
+}
+
 if [[ "$SHOULD_BUILD" == "yes" ]]; then
   cp -rp src/* vscode/
   cd vscode
@@ -57,7 +64,13 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
 
   yarn gulp compile-build
   yarn gulp compile-extensions-build
+
+  # this task is very slow on mac, so using a keep alive to keep travis alive
+  keep_alive &
+  KA_PID=$!
   yarn gulp minify-vscode
+  kill $KA_PID
+
   yarn gulp minify-vscode-reh
   yarn gulp minify-vscode-reh-web
 
@@ -81,7 +94,6 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     yarn gulp vscode-reh-linux-x64-min-ci
     yarn gulp vscode-reh-web-linux-x64-min-ci
 
-    yarn gulp "vscode-linux-${BUILDARCH}-min"
     yarn gulp "vscode-linux-${BUILDARCH}-build-deb"
     yarn gulp "vscode-linux-${BUILDARCH}-build-rpm"
     . ../create_appimage.sh

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+function keep_alive() {
+  while true; do
+    date
+    sleep 60
+  done
+}
+
+function build() {
+  keep_alive &
+  KA_PID=$!
+  npm run gulp -- $1
+  kill $KA_PID
+}
+
 if [[ "$SHOULD_BUILD" == "yes" ]]; then
   cp -rp src/* vscode/
   cd vscode
@@ -55,18 +70,18 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
 
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     npm install --global create-dmg
-    travis_wait npm run gulp -- "vscode-darwin-min"
+    build "vscode-darwin-min"
   elif [[ "$CI_WINDOWS" == "True" ]]; then
     cp LICENSE.txt LICENSE.rtf # windows build expects rtf license
-    npm run gulp -- "vscode-win32-${BUILDARCH}-min"
-    npm run gulp -- "vscode-win32-${BUILDARCH}-inno-updater"
-    npm run gulp -- "vscode-win32-${BUILDARCH}-system-setup"
-    npm run gulp -- "vscode-win32-${BUILDARCH}-user-setup"
-    npm run gulp -- "vscode-win32-${BUILDARCH}-archive"
+    build "vscode-win32-${BUILDARCH}-min"
+    build "vscode-win32-${BUILDARCH}-inno-updater"
+    build "vscode-win32-${BUILDARCH}-system-setup"
+    build "vscode-win32-${BUILDARCH}-user-setup"
+    build "vscode-win32-${BUILDARCH}-archive"
   else # linux
-    npm run gulp -- "vscode-linux-${BUILDARCH}-min"
-    npm run gulp -- "vscode-linux-${BUILDARCH}-build-deb"
-    npm run gulp -- "vscode-linux-${BUILDARCH}-build-rpm"
+    build "vscode-linux-${BUILDARCH}-min"
+    build "vscode-linux-${BUILDARCH}-build-deb"
+    build "vscode-linux-${BUILDARCH}-build-rpm"
     . ../create_appimage.sh
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
 
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     npm install --global create-dmg
-    npm run gulp -- "vscode-darwin-min"
+    travis_wait npm run gulp -- "vscode-darwin-min"
   elif [[ "$CI_WINDOWS" == "True" ]]; then
     cp LICENSE.txt LICENSE.rtf # windows build expects rtf license
     npm run gulp -- "vscode-win32-${BUILDARCH}-min"


### PR DESCRIPTION
- Update to use new gulp tasks
- Wrap `yarn gulp minify-vscode` in a `keep_alive` script so that Travis doesn't give up after 10 minutes

Max execution time for a public repo build is 50 minutes, and sometimes the Darwin build exceeds that. We will need to find some ways of trimming down that time to make these builds safer.