### PR TITLE
Set BUILD_SOURCEVERSION to LATEST_MS_COMMIT explicitly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,10 @@ function keep_alive() {
 }
 
 if [[ "$SHOULD_BUILD" == "yes" ]]; then
+  export BUILD_SOURCEVERSION=$LATEST_MS_COMMIT
+  echo "LATEST_MS_COMMIT: ${LATEST_MS_COMMIT}"
+  echo "BUILD_SOURCEVERSION: ${BUILD_SOURCEVERSION}"
+
   cp -rp src/* vscode/
   cd vscode
 


### PR DESCRIPTION
Have confirmed that the produced Windows assets have proper commit hash in product.json

Fixes #222 

Will take affect in next released build.