### PR TITLE
Stop triggering Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
 
 script:
   - ./build.sh
-  - ./trigger-azure.sh
 
 before_deploy:
   - ./sign_mac_app.sh

--- a/trigger-azure.sh
+++ b/trigger-azure.sh
@@ -1,7 +1,0 @@
-if [ "$AZURE_TOKEN" != "" ]; then
-  if [[ "$SHOULD_BUILD" == "yes" ]]; then
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      curl -X POST -H "Content-Type: application/json" -H "Authorization: Basic $AZURE_TOKEN" -d '{"definition":{"id":1}}' https://dev.azure.com/VSCodium/vscodium/_apis/build/builds?api-version=5.0-preview.5
-    fi
-  fi
-fi


### PR DESCRIPTION
It appears that Azure Pipelines is now able to keep up with running scheduled builds, so triggering an extra build causes a race condition.