### PR TITLE
Update TravisCI config to use Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
     - os: linux
       sudo: required
       env: BUILDARCH=x64
+      dist: trusty
     - os: osx
 
 language: node_js


### PR DESCRIPTION
"As of August, 13th 2019, we’ve switched the default Linux distribution on Travis CI from Ubuntu Trusty 14.04 LTS to Ubuntu Xenial 16.04. Here are the most common issues our customers ran into and how you can fix them." - https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide

Tested and fixed the version of Ubuntu used by TravisCI to Ubuntu 14 (trusty), as the default changed in August (and broke compatibility with RHEL 7, CentOS 7, and deviated from VS Code's official builds).