### PR TITLE
Update create_appimage.sh

### DIFF
--- a/create_appimage.sh
+++ b/create_appimage.sh
@@ -3,8 +3,8 @@ if [[ "$BUILDARCH" == "x64" ]]; then
   # install a dep needed for this process
   sudo apt-get install desktop-file-utils
 
-  # download pkg2appimage from github
-  curl -LO "https://github.com/AppImage/pkg2appimage/raw/master/pkg2appimage"
+  # download modified pkg2appimage from gist
+  curl -LO "https://gist.githubusercontent.com/tyu1996/39b8a7a29c2cdeef882daaa1702ec971/raw/2e788010deafb2f1214439ee0bc8e46685480e45/pkg2appimage"
   
   bash -e pkg2appimage ../VSCodium-AppImage-Recipe.yml
 fi


### PR DESCRIPTION
Addresses issue #253 
Modified pkg2appimage removes PYTHONPATH & PYTHONHOME exportations.