### PR TITLE
Add hacky, initial arm64 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ matrix:
       sudo: required
       env: BUILDARCH=x64
       dist: trusty
+    - os: linux
+      sudo: required
+      env: BUILDARCH=arm64
+      dist: trusty
     - os: osx
 
 language: node_js

--- a/README.md
+++ b/README.md
@@ -103,11 +103,10 @@ The builds are run every day, but exit early if there isn't a new release from M
 - [x] OS X (`zip`, `dmg`)
 - [x] Linux x64 (`deb`, `rpm`, `AppImage`, `tar.gz`)
 - [x] Linux x86 (`deb`, `rpm`, `tar.gz`) ([up to v1.35.1](https://code.visualstudio.com/updates/v1_36#_linux-32bit-support-ends))
+- [x] Linux arm64 (`deb`, `tar.gz`)
 - [x] Windows x64
 - [x] Windows x86
   
-The ARM architecture is not currently supported but is being worked on.
-
 ## <a id="donate"></a>Donate
 If you would like to support the development of VSCodium, feel free to send BTC to `3PgjE95yzBDTrSPxPiqoxSgZFuKPPAix1N`.
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,18 +5,24 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install jq zip
 else
   sudo apt-get update
-  sudo apt-get install -y fakeroot rpm jq
+  sudo apt-get install -y fakeroot jq
   if [[ $BUILDARCH == "arm64" ]]; then
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/arm64.list >/dev/null
+    sed 's/^deb /deb [arch=amd64] '/g -i /etc/apt/sources.list
+    echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/arm64.list >/dev/null
     sudo dpkg --add-architecture arm64
     sudo apt-get update
-    sudo apt-get install libc6-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-    sudo apt-get install libx11-dev:arm64 libxkbfile-dev:arm64
+    sudo apt-get install libc6-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
+    mkdir -p dl
+    cd dl
+    apt-get download libx11-dev:arm64 libx11-6:arm64 libxkbfile-dev:arm64 libxkbfile1:arm64 libxau-dev:arm64 libxdmcp-dev:arm64 libxcb1-dev:arm64 libsecret-1-dev:arm64 libsecret-1-0:arm64 libpthread-stubs0-dev:arm64 libglib2.0-dev:arm64 libglib2.0-0:arm64 libffi-dev:arm64 libffi6:arm64 zlib1g:arm64 libpcre3-dev:arm64 libpcre3:arm64
+    for i in *.deb; do ar x $i; sudo tar -C / -xf data.tar.*; rm -f data.tar.*; done
+    cd ..
     export CC=/usr/bin/aarch64-linux-gnu-gcc
     export CXX=/usr/bin/aarch64-linux-gnu-g++
     export CC_host=/usr/bin/gcc
     export CXX_host=/usr/bin/g++
+    export PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
   else
-    sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm jq
+    sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev rpm
   fi
 fi

--- a/sum.sh
+++ b/sum.sh
@@ -28,8 +28,8 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     sum_file VSCodium-win32-*.zip
   else # linux
     cp out/*.AppImage .
-    cp vscode/.build/linux/deb/amd64/deb/*.deb .
-    cp vscode/.build/linux/rpm/x86_64/*.rpm .
+    cp vscode/.build/linux/deb/*/deb/*.deb .
+    cp vscode/.build/linux/rpm/*/*.rpm .
 
     sum_file *.AppImage
     sum_file VSCodium-linux*.tar.gz


### PR DESCRIPTION
The `build.sh` changes can be cleaned up a little bit thanks to https://github.com/microsoft/node-native-keymap/commit/e31be382147decfbdf943ba0e63acc920098fd06 and https://github.com/microsoft/vscode/pull/86659 (by using `PKG_CONFIG=pkg-config-aarch64-linux-gnu`), but it would be better to give something to those desiring a working arm64 build, then iterate from there.