### PR TITLE
Add hacky, initial armhf support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ matrix:
       sudo: required
       env: BUILDARCH=x64
       dist: trusty
+    - os: linux
+      sudo: required
+      env: BUILDARCH=arm64
+      dist: trusty
     - os: osx
 
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
       sudo: required
       env: BUILDARCH=arm64
       dist: trusty
+    - os: linux
+      sudo: required
+      env: BUILDARCH=arm
+      dist: trusty
     - os: osx
 
 language: node_js

--- a/README.md
+++ b/README.md
@@ -103,11 +103,10 @@ The builds are run every day, but exit early if there isn't a new release from M
 - [x] OS X (`zip`, `dmg`)
 - [x] Linux x64 (`deb`, `rpm`, `AppImage`, `tar.gz`)
 - [x] Linux x86 (`deb`, `rpm`, `tar.gz`) ([up to v1.35.1](https://code.visualstudio.com/updates/v1_36#_linux-32bit-support-ends))
+- [x] Linux arm64 (`deb`, `tar.gz`)
 - [x] Windows x64
 - [x] Windows x86
   
-The ARM architecture is not currently supported but is being worked on.
-
 ## <a id="donate"></a>Donate
 If you would like to support the development of VSCodium, feel free to send BTC to `3PgjE95yzBDTrSPxPiqoxSgZFuKPPAix1N`.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The builds are run every day, but exit early if there isn't a new release from M
 - [x] Linux x64 (`deb`, `rpm`, `AppImage`, `tar.gz`)
 - [x] Linux x86 (`deb`, `rpm`, `tar.gz`) ([up to v1.35.1](https://code.visualstudio.com/updates/v1_36#_linux-32bit-support-ends))
 - [x] Linux arm64 (`deb`, `tar.gz`)
+- [x] Linux armhf (`deb`, `tar.gz`)
 - [x] Windows x64
 - [x] Windows x86
   

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     yarn gulp vscode-reh-web-linux-${BUILDARCH}-min-ci
 
     yarn gulp "vscode-linux-${BUILDARCH}-build-deb"
-    if [[ "$BUILDARCH" != "arm64" ]]; then
+    if [[ "$BUILDARCH" == "x64" ]]; then
       yarn gulp "vscode-linux-${BUILDARCH}-build-rpm"
     fi
     . ../create_appimage.sh

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -34,6 +34,20 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
         echo "Already have all the Linux arm64 builds"
       fi
+    elif [[ $BUILDARCH == "arm" ]]; then
+      HAVE_ARM_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["armhf.deb"])')
+      HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "armhf-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+      if [[ "$HAVE_ARM_DEB" != "true" ]]; then
+        echo "Building on Linux arm because we have no DEB"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$HAVE_ARM_TAR" != "true" ]]; then
+        echo "Building on Linux arm because we have no TAR"
+        export SHOULD_BUILD="yes"
+      fi
+      if [[ "$SHOULD_BUILD" != "yes" ]]; then
+        echo "Already have all the Linux arm builds"
+      fi
     else
       HAVE_64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["x86_64.rpm"])')
       HAVE_64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["amd64.deb"])')

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -4,12 +4,9 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     cd VSCode-darwin
     zip -r -X -y ../VSCodium-darwin-${LATEST_MS_TAG}.zip ./*.app
-  elif [[ "$BUILDARCH" == "arm64" ]]; then
-    cd VSCode-linux-arm64
-    tar czf ../VSCodium-linux-arm64-${LATEST_MS_TAG}.tar.gz .
   else
-    cd VSCode-linux-x64
-    tar czf ../VSCodium-linux-x64-${LATEST_MS_TAG}.tar.gz .
+    cd VSCode-linux-${BUILDARCH}
+    tar czf ../VSCodium-linux-${BUILDARCH}-${LATEST_MS_TAG}.tar.gz .
   fi
 
   cd ..

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -6,22 +6,35 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 else
   sudo apt-get update
   sudo apt-get install -y fakeroot jq
-  if [[ $BUILDARCH == "arm64" ]]; then
+  triplet=
+  case $BUILDARCH in
+  arm)
+    arch=armhf
+    triplet=arm-linux-gnueabihf
+    ;;
+
+  arm64)
+    arch=arm64
+    triplet=aarch64-linux-gnu
+    ;;
+  esac
+
+  if [[ -n "$triplet" ]]; then
     sed 's/^deb /deb [arch=amd64] '/g -i /etc/apt/sources.list
-    echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/arm64.list >/dev/null
-    sudo dpkg --add-architecture arm64
+    echo "deb [arch=$arch] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/$arch.list >/dev/null
+    sudo dpkg --add-architecture $arch
     sudo apt-get update
-    sudo apt-get install libc6-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
+    sudo apt-get install libc6-dev-$arch-cross gcc-$triplet g++-$triplet `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
     mkdir -p dl
     cd dl
-    apt-get download libx11-dev:arm64 libx11-6:arm64 libxkbfile-dev:arm64 libxkbfile1:arm64 libxau-dev:arm64 libxdmcp-dev:arm64 libxcb1-dev:arm64 libsecret-1-dev:arm64 libsecret-1-0:arm64 libpthread-stubs0-dev:arm64 libglib2.0-dev:arm64 libglib2.0-0:arm64 libffi-dev:arm64 libffi6:arm64 zlib1g:arm64 libpcre3-dev:arm64 libpcre3:arm64
+    apt-get download libx11-dev:$arch libx11-6:$arch libxkbfile-dev:$arch libxkbfile1:$arch libxau-dev:$arch libxdmcp-dev:$arch libxcb1-dev:$arch libsecret-1-dev:$arch libsecret-1-0:$arch libpthread-stubs0-dev:$arch libglib2.0-dev:$arch libglib2.0-0:$arch libffi-dev:$arch libffi6:$arch zlib1g:$arch libpcre3-dev:$arch libpcre3:$arch
     for i in *.deb; do ar x $i; sudo tar -C / -xf data.tar.*; rm -f data.tar.*; done
     cd ..
-    export CC=/usr/bin/aarch64-linux-gnu-gcc
-    export CXX=/usr/bin/aarch64-linux-gnu-g++
+    export CC=/usr/bin/$triplet-gcc
+    export CXX=/usr/bin/$triplet-g++
     export CC_host=/usr/bin/gcc
     export CXX_host=/usr/bin/g++
-    export PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+    export PKG_CONFIG_LIBDIR=/usr/lib/$triplet/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
   else
     sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev rpm
   fi

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,18 +5,24 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   brew install jq zip
 else
   sudo apt-get update
-  sudo apt-get install -y fakeroot rpm jq
+  sudo apt-get install -y fakeroot jq
   if [[ $BUILDARCH == "arm64" ]]; then
-    echo "deb http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/arm64.list >/dev/null
+    sed 's/^deb /deb [arch=amd64] '/g -i /etc/apt/sources.list
+    echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/arm64.list >/dev/null
     sudo dpkg --add-architecture arm64
     sudo apt-get update
-    sudo apt-get install libc6-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-    sudo apt-get install libx11-dev:arm64 libxkbfile-dev:arm64
+    sudo apt-get install libc6-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
+    mkdir -p dl
+    cd dl
+    apt-get download libx11-dev:arm64 libx11-6:arm64 libxkbfile-dev:arm64 libxkbfile1:arm64 libxau-dev:arm64 libxdmcp-dev:arm64 libxcb1-dev:arm64 libsecret-1-dev:arm64 libsecret-1-0:arm64 libpthread-stubs0-dev:arm64 libglib2.0-dev:arm64 libglib2.0-0:arm64 libffi-dev:arm64 libffi6:arm64 zlib1g:arm64 libpcre3-dev:arm64 libpcre3:arm64
+    for i in *.deb; do ar x $i; sudo tar -C / -xf data.tar.*; rm -f data.tar.*; done
+    cd ..
     export CC=/usr/bin/aarch64-linux-gnu-gcc
     export CXX=/usr/bin/aarch64-linux-gnu-g++
     export CC_host=/usr/bin/gcc
     export CXX_host=/usr/bin/g++
+    export PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
   else
-    sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev fakeroot rpm jq
+    sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev rpm
   fi
 fi

--- a/sum.sh
+++ b/sum.sh
@@ -28,8 +28,8 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     sum_file VSCodium-win32-*.zip
   else # linux
     cp out/*.AppImage .
-    cp vscode/.build/linux/deb/amd64/deb/*.deb .
-    cp vscode/.build/linux/rpm/x86_64/*.rpm .
+    cp vscode/.build/linux/deb/*/deb/*.deb .
+    cp vscode/.build/linux/rpm/*/*.rpm .
 
     sum_file *.AppImage
     sum_file VSCodium-linux*.tar.gz


### PR DESCRIPTION
This is a superset of #302 that fixes the rest of #6, by adding 32-bit (ARMv7) support.

~~I opened a separate PR, since there's a possibility that it's going to take time for me to fix the ARMv7 hardware I can test this on. File sizes (.deb, .tar.gz, etc') look sane, though.~~

~~I'll test this on my arm64 Chromebook, with 32-bit support libraries installed.~~

Tested on my RK3288 Chromebook (Cortex A 17).

![](https://i.imgur.com/bp3zeDI.png)