### PR TITLE
Add an APT repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,25 +24,36 @@ before_deploy:
   - ./create_zip.sh
   - ./create_dmg.sh
   - ./sum.sh
+  - ./clean_repo.sh
 
 deploy:
-  provider: releases
-  skip_cleanup: true
-  overwrite: true
-  name: $LATEST_MS_TAG
-  api_key: $GITHUB_TOKEN
-  file_glob: true
-  file:
-    - ./*.sha256
-    - ./*.zip
-    - ./*.tar.gz
-    - ./*.dmg
-    - ./*.deb
-    - ./*.rpm
-    - ./*.AppImage
-  on:
-    all_branches: true
-    condition: $SHOULD_BUILD = yes
+  - provider: releases
+    skip_cleanup: true
+    overwrite: true
+    name: $LATEST_MS_TAG
+    api_key: $GITHUB_TOKEN
+    file_glob: true
+    file:
+      - ./*.sha256
+      - ./*.zip
+      - ./*.tar.gz
+      - ./*.dmg
+      - ./*.deb
+      - ./*.rpm
+      - ./*.AppImage
+    on:
+      all_branches: true
+      condition: $SHOULD_BUILD = yes
+  - provider: packagecloud
+    skip_cleanup: true
+    package_glob: "*.deb"
+    repository: vscodium
+    username: dimkr
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ubuntu/trusty
+    on:
+      all_branches: true
+      condition: $SHOULD_BUILD = yes
 
 after_deploy:
   - ./update_version.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![build status](https://travis-ci.com/VSCodium/vscodium.svg?branch=master)](https://travis-ci.com/VSCodium/vscodium) 
 [![license](https://img.shields.io/github/license/VSCodium/vscodium.svg)](https://github.com/VSCodium/vscodium/blob/master/LICENSE)
 [![Gitter](https://img.shields.io/gitter/room/vscodium/vscodium.svg)](https://gitter.im/VSCodium/Lobby)
+[![apt repository](https://img.shields.io/badge/apt-repository-brightgreen?logo=debian)](https://packagecloud.io/dimkr/vscodium)
 
 </div>
 
@@ -56,7 +57,14 @@ scoop install vscodium
 ```
 
 #### <a id="install-with-package-manager"></a>Install with Package Manager (Linux)
-You can always install using the downloads (deb, rpm, tar) on the [releases page](https://github.com/VSCodium/vscodium/releases), but you can also install using your favorite package manager and get automatic updates. [@paulcarroty](https://github.com/paulcarroty) has set up a repository with instructions [here](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo). Any issues installing VSCodium using your package manager should be directed to that repository's issue tracker. 
+You can always install using the downloads (deb, rpm, tar) on the [releases page](https://github.com/VSCodium/vscodium/releases), but you can also install from [the APT repository](https://packagecloud.io/dimkr/vscodium) using your favorite package manager and get automatic updates:
+
+```bash
+curl -s https://packagecloud.io/install/repositories/dimkr/vscodium/script.deb.sh | sudo os=ubuntu dist=trusty bash
+sudo apt install codium
+```
+
+[@paulcarroty](https://github.com/paulcarroty) has set up a repository too, with instructions [here](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo). Any issues installing VSCodium from this repository should be directed to the repository's issue tracker.
 
 #### <a id="install-on-arch-linux"></a>Install on Arch Linux
 VSCodium is available in [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) as package [vscodium-bin](https://aur.archlinux.org/packages/vscodium-bin/), maintained by [@plague-doctor](https://github.com/plague-doctor).

--- a/clean_repo.sh
+++ b/clean_repo.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -xe
+
+arch="${BUILDARCH}"
+case "$arch" in
+x64)
+    arch="amd64"
+    ;;
+arm)
+    arch="armhf"
+    ;;
+esac
+
+# delete old packages for $BUILDARCH, to stay within the free tier space limitation
+curl -s "https://${PACKAGECLOUD_TOKEN}:@packagecloud.io/api/v1/repos/dimkr/vscodium/packages.json" | jq -r '.[].destroy_url' | grep -F "${arch}.deb" | while read destroy_url
+do
+    curl -X DELETE "https://${PACKAGECLOUD_TOKEN}:@packagecloud.io${destroy_url}"
+done


### PR DESCRIPTION
https://packagecloud.io/dimkr/vscodium needs to be replaced with https://packagecloud.io/vscodium/vscodium (and its API token).

The free tier should be enough: old packages for `$BUILDARCH` are removed before new ones are uploaded. `apt upgrade` works.