### PR TITLE
Use pkg-config for cross-builds

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -24,7 +24,7 @@ else
     echo "deb [arch=$arch] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/$arch.list >/dev/null
     sudo dpkg --add-architecture $arch
     sudo apt-get update
-    sudo apt-get install libc6-dev-$arch-cross gcc-$triplet g++-$triplet `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
+    sudo apt-get install libc6-dev-$arch-cross gcc-$triplet g++-$triplet pkg-config-$triplet `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
     mkdir -p dl
     cd dl
     apt-get download libx11-dev:$arch libx11-6:$arch libxkbfile-dev:$arch libxkbfile1:$arch libxau-dev:$arch libxdmcp-dev:$arch libxcb1-dev:$arch libsecret-1-dev:$arch libsecret-1-0:$arch libpthread-stubs0-dev:$arch libglib2.0-dev:$arch libglib2.0-0:$arch libffi-dev:$arch libffi6:$arch zlib1g:$arch libpcre3-dev:$arch libpcre3:$arch
@@ -34,7 +34,7 @@ else
     export CXX=/usr/bin/$triplet-g++
     export CC_host=/usr/bin/gcc
     export CXX_host=/usr/bin/g++
-    export PKG_CONFIG_LIBDIR=/usr/lib/$triplet/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+    export PKG_CONFIG=$triplet-pkg-config
   else
     sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev rpm
   fi


### PR DESCRIPTION
Now that https://github.com/microsoft/vscode/pull/86659 is merged, clean cross-compilation is possible. 

We specify the compilers and the `pkg-config` to use and take advantage of `apt-get download` to fetch dependency packages for the target architecture. Since these are Ubuntu packages, libraries go to per-architecture paths, so we can safely extract the packages to / and the library paths returned by the `pkg-config` wrapper lead the linker to those paths.

__This PR can be tested only when the next version is tagged.__