### PR TITLE
Fix appimage icon

### DIFF
--- a/VSCodium-AppImage-Recipe.yml
+++ b/VSCodium-AppImage-Recipe.yml
@@ -20,8 +20,7 @@ ingredients:
     - ls codium_*.deb | cut -d _ -f 2 > VERSION
 
 script:
-  - sed -i -e 's|/usr/share/codium/||g' usr/share/applications/codium.desktop
-  - sed -i -e 's|com.visualstudio.code.oss|vscodium|g' usr/share/applications/codium.desktop
+  - sed -i -e 's|/usr/share/pixmaps/||g' usr/share/applications/codium.desktop
   - cp usr/share/applications/codium.desktop .
   - cp usr/share/pixmaps/vscodium.png vscodium.png
   - convert vscodium.png -resize 512x512 usr/share/icons/hicolor/512x512/apps/vscodium.png
@@ -30,6 +29,4 @@ script:
   - convert vscodium.png -resize 64x64 usr/share/icons/hicolor/64x64/apps/vscodium.png
   - convert vscodium.png -resize 48x48 usr/share/icons/hicolor/48x48/apps/vscodium.png
   - convert vscodium.png -resize 32x32 usr/share/icons/hicolor/32x32/apps/vscodium.png
-  - convert vscodium.png -resize 24x24 usr/share/icons/hicolor/24x24/apps/vscodium.png
-  - convert vscodium.png -resize 22x22 usr/share/icons/hicolor/22x22/apps/vscodium.png
   - ( cd usr/bin/ ; ln -s ../share/codium/codium  . )


### PR DESCRIPTION
fix https://github.com/VSCodium/vscodium/issues/322
Remove 22x22 and 24x24 icon to make appimagelint happier. 
After this change:

<details>
<summary>appimagelint output</summary>

```
./appimagelint-x86_64.AppImage --check icons_check ./vscodium/out/VSCodium-1.43.2-1585083818.glibc2.16-x86_64.AppImage 
appimagelint.cli[11954] [INFO] Checking AppImage ./vscodium/out/VSCodium-1.43.2-1585083818.glibc2.16-x86_64.AppImage
appimagelint.cli[11954] [INFO] Running check "Icons validity and location check"
appimagelint.icons_check[11954] [INFO] Extracting icon name from desktop file: /tmp/.mount_VSCodihQEnYm/codium.desktop
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/vscodium.png
appimagelint.icons_check[11954] [WARNING] icon X resolution 1024 is unknown, icon will most likely not be used and just wastes space
appimagelint.icons_check[11954] [WARNING] icon Y resolution 1024 is unknown, icon will most likely not be used and just wastes space
appimagelint.icons_check[11954] [INFO] [✔] Valid icon in AppDir root
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/.DirIcon
appimagelint.icons_check[11954] [WARNING] icon X resolution 1024 is unknown, icon will most likely not be used and just wastes space
appimagelint.icons_check[11954] [WARNING] icon Y resolution 1024 is unknown, icon will most likely not be used and just wastes space
appimagelint.icons_check[11954] [INFO] [✔] Valid icon file in .DirIcon
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/usr/share/icons/hicolor/128x128/apps/vscodium.png
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/usr/share/icons/hicolor/256x256/apps/vscodium.png
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/usr/share/icons/hicolor/32x32/apps/vscodium.png
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/usr/share/icons/hicolor/48x48/apps/vscodium.png
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/usr/share/icons/hicolor/512x512/apps/vscodium.png
appimagelint.icons_check[11954] [INFO] Checking resolution of icon: /tmp/.mount_VSCodihQEnYm/usr/share/icons/hicolor/64x64/apps/vscodium.png
appimagelint.icons_check[11954] [INFO] [✔] Other integration icons valid
```

</details>
