### PR TITLE
Add update information for appimage

### DIFF
--- a/src/resources/linux/appimage/functions.sh
+++ b/src/resources/linux/appimage/functions.sh
@@ -241,9 +241,9 @@ generate_type2_appimage()
     tar xf data.tar.gz
     sudo chown -R $USER .gnu*
     mv $HOME/.gnu* $HOME/.gnu_old ; mv .gnu* $HOME/
-    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/ -u "gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"
   else
-    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/ -u "gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"
   fi
   set -x
   mkdir -p ../out/ || true

--- a/src/resources/linux/appimage/functions.sh
+++ b/src/resources/linux/appimage/functions.sh
@@ -241,9 +241,9 @@ generate_type2_appimage()
     tar xf data.tar.gz
     sudo chown -R $USER .gnu*
     mv $HOME/.gnu* $HOME/.gnu_old ; mv .gnu* $HOME/
-    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/ -u "gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
   else
-    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/ -u "gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"
+    VERSION=$VERSION_EXPANDED "$appimagetool" $@ -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
   fi
   set -x
   mkdir -p ../out/ || true

--- a/src/resources/linux/appimage/pkg2appimage
+++ b/src/resources/linux/appimage/pkg2appimage
@@ -163,7 +163,7 @@ fi
 # and ingredients of that architecture. Debian packages
 # should be available for most architectures, e.g., oldstable
 # has "armhf"
-if [ ! -z $ARCH] ; then
+if [ ! -z $ARCH ] ; then
   OPTIONS="$OPTIONS -o APT::Architecture=$ARCH"
 fi
 
@@ -467,6 +467,5 @@ fi
 # Go out of AppImage
 cd ..
 
-export UPDATE_INFORMATION="gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"
 generate_type2_appimage
 ls -lh ../out/*.AppImage*

--- a/src/resources/linux/appimage/pkg2appimage
+++ b/src/resources/linux/appimage/pkg2appimage
@@ -467,5 +467,5 @@ fi
 # Go out of AppImage
 cd ..
 
-generate_type2_appimage
+generate_type2_appimage -u "gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"
 ls -lh ../out/*.AppImage*


### PR DESCRIPTION
https://github.com/VSCodium/vscodium/pull/346 use a env variable `UPDATE_INFORMATION` but I can't find docs about it and it doesn't work. So I follow https://docs.appimage.org/packaging-guide/optional/updates.html#using-appimagetool instead. It works locally.

```
+ mv VSCodium-1.45.0-1588934730.glibc2.16-x86_64.AppImage VSCodium-1.45.0-1588934730.glibc2.16-x86_64.AppImage.zsync ../out/
+ ls -lh ../out/VSCodium-1.45.0-1588934730.glibc2.16-x86_64.AppImage ../out/VSCodium-1.45.0-1588934730.glibc2.16-x86_64.AppImage.zsync
-rwxr-xr-x 1 ult ult  89M 5月  20 17:07 ../out/VSCodium-1.45.0-1588934730.glibc2.16-x86_64.AppImage
-rw-rw-r-- 1 ult ult 311K 5月  20 17:07 ../out/VSCodium-1.45.0-1588934730.glibc2.16-x86_64.AppImage.zsync
```

![2020_05_20_104339](https://user-images.githubusercontent.com/36977733/82460369-98628c80-9aa8-11ea-98d0-b7f33c3b8878.png)
