### PR TITLE
Fix sqlite error on ARM build

### DIFF
--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -13,6 +13,14 @@ patch -u src/vs/platform/update/electron-main/updateService.win32.ts -i ../patch
 
 yarn --frozen-lockfile
 yarn postinstall
+
+if [[ "$BUILDARCH" == *"arm"* ]]; then
+  sed -i -z 's/,\n[^\n]*arm[^\n]*//' node_modules/vscode-sqlite3/binding.gyp
+  sed -i "s/Release\/sqlite'/Release\/sqlite.node'/" node_modules/vscode-sqlite3/lib/sqlite3.js
+  yarn add -D electron-rebuild
+  npx electron-rebuild -f -w vscode-sqlite3
+fi
+
 mv product.json product.json.bak
 
 # set fields in product.json


### PR DESCRIPTION
Fix vscode sqlite error that makes welcome messages (notification, extension welcome pages) appear every time on vscode startup.