### PR TITLE
Fix arm builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vscode_arch: [x64, arm64, armhf]
+        vscode_arch: [x64, arm64, arm]
         include:
         - vscode_arch: x64
           npm_arch: x64

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,19 +10,17 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.probably_fails }}
+    container: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64, arm64]
-        probably_fails: [false]
-        include:
-          - arch: arm
-            probably_fails: true
+        vscode_arch: [x64, arm64, armhf]
+        npm_arch: [x64, arm64, armv7l]
+        image: ['vscodehub.azurecr.io/vscode-linux-build-agent:x64', 'vscodehub.azurecr.io/vscode-linux-build-agent:buster-arm64', 'vscodehub.azurecr.io/vscode-linux-build-agent:buster-armhf']
 
     env:
       OS_NAME: 'linux'
-      BUILDARCH: ${{ matrix.arch }}
+      VSCODE_ARCH: ${{ matrix.vscode_arch }}
     steps:
       - uses: actions/checkout@v2
 
@@ -44,57 +42,17 @@ jobs:
           . check_tags.sh
           echo "::set-env name=SHOULD_BUILD::$SHOULD_BUILD"
 
-      - name: Install build deps
-        run: |
-          triplet=
-          case $BUILDARCH in
-            arm)
-              arch=armhf
-              triplet=arm-linux-gnueabihf
-              ;;
-
-            arm64)
-              arch=arm64
-              triplet=aarch64-linux-gnu
-              ;;
-          esac
-
-          if [[ -n "$triplet" ]]; then
-            sudo sed 's/^deb /deb [arch=amd64] '/g -i /etc/apt/sources.list
-            echo "deb [arch=$arch] http://ports.ubuntu.com/ubuntu-ports/ trusty main" | sudo tee -a /etc/apt/sources.list.d/$arch.list >/dev/null
-            sudo dpkg --add-architecture $arch
-            sudo apt-get update
-            sudo apt-get install libc6-dev-$arch-cross gcc-$triplet g++-$triplet `apt-cache search x11proto | grep ^x11proto | cut -f 1 -d ' '` xz-utils pkg-config
-            mkdir -p dl
-            pushd dl
-            apt-get download libx11-dev:$arch libx11-6:$arch libxkbfile-dev:$arch libxkbfile1:$arch libxau-dev:$arch libxdmcp-dev:$arch libxcb1-dev:$arch libsecret-1-dev:$arch libsecret-1-0:$arch libpthread-stubs0-dev:$arch libglib2.0-dev:$arch libglib2.0-0:$arch libffi-dev:$arch libffi6:$arch zlib1g:$arch libpcre3-dev:$arch libpcre3:$arch
-            for i in *.deb; do ar x $i; sudo tar -C / -xf data.tar.*; rm -f data.tar.*; done
-            popd
-            echo "::set-env name=CC::/usr/bin/$triplet-gcc"
-            echo "::set-env name=CXX::/usr/bin/$triplet-g++"
-            echo "::set-env name=CC_host::/usr/bin/gcc"
-            echo "::set-env name=CXX_host::/usr/bin/g++"
-            echo "::set-env name=PKG_CONFIG_LIBDIR::/usr/lib/$triplet/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig"
-            export CC=/usr/bin/$triplet-gcc
-            export CXX=/usr/bin/$triplet-g++
-            export CC_host=/usr/bin/gcc
-            export CXX_host=/usr/bin/g++
-            export PKG_CONFIG_LIBDIR=/usr/lib/$triplet/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
-          fi
-        if: env.SHOULD_BUILD == 'yes'
-          
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          npm_config_arch: ${{ matrix.arch }}
-          npm_config_target_arch: ${{ matrix.arch }}
+          npm_config_arch: ${{ matrix.npm_arch }}
         run: ./build.sh
         if: env.SHOULD_BUILD == 'yes'
 
       - name: Zip release
         run: |
-          cd VSCode-linux-${BUILDARCH}
-          tar czf ../VSCodium-linux-${BUILDARCH}-${LATEST_MS_TAG}.tar.gz .
+          cd VSCode-linux-${VSCODE_ARCH}
+          tar czf ../VSCodium-linux-${VSCODE_ARCH}-${LATEST_MS_TAG}.tar.gz .
         if: env.SHOULD_BUILD == 'yes'
 
       - name: Generate shasums

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           node-version: 12.14.1
 
+      - name: Install Yarn
+        run: npm install -g yarn
+
       - name: Clone VSCode repo
         run: ./get_repo.sh
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,12 +15,21 @@ jobs:
       fail-fast: false
       matrix:
         vscode_arch: [x64, arm64, armhf]
-        npm_arch: [x64, arm64, armv7l]
-        image: ['vscodehub.azurecr.io/vscode-linux-build-agent:x64', 'vscodehub.azurecr.io/vscode-linux-build-agent:buster-arm64', 'vscodehub.azurecr.io/vscode-linux-build-agent:buster-armhf']
+        include:
+        - vscode_arch: x64
+          npm_arch: x64
+          image: vscodehub.azurecr.io/vscode-linux-build-agent:x64
+        - vscode_arch: arm64
+          npm_arch: arm64
+          image: vscodehub.azurecr.io/vscode-linux-build-agent:buster-arm64
+        - vscode_arch: armhf
+          npm_arch: armv7l
+          image: vscodehub.azurecr.io/vscode-linux-build-agent:buster-armhf
 
     env:
       OS_NAME: 'linux'
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,23 +39,13 @@ jobs:
         with:
           node-version: 12.14.1
 
-      - name: Debug
-        run: |
-          ls -al
-          ls /__w
-
       - name: Clone VSCode repo
-        run: |
-          . get_repo.sh
-          echo "::set-env name=LATEST_MS_TAG::$LATEST_MS_TAG"
-          echo "::set-env name=LATEST_MS_COMMIT::$LATEST_MS_COMMIT"
+        run: ./get_repo.sh
 
       - name: Check existing VSCodium tags/releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          . check_tags.sh
-          echo "::set-env name=SHOULD_BUILD::$SHOULD_BUILD"
+        run: ./check_tags.sh
 
       - name: Build
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,13 +18,13 @@ jobs:
         include:
         - vscode_arch: x64
           npm_arch: x64
-          image: vscodehub.azurecr.io/vscode-linux-build-agent:x64
+          image: vscodium/vscodium-linux-build-agent:x64
         - vscode_arch: arm64
           npm_arch: arm64
-          image: vscodehub.azurecr.io/vscode-linux-build-agent:buster-arm64
+          image: vscodium/vscodium-linux-build-agent:buster-arm64
         - vscode_arch: armhf
           npm_arch: armv7l
-          image: vscodehub.azurecr.io/vscode-linux-build-agent:buster-armhf
+          image: vscodium/vscodium-linux-build-agent:buster-armhf
 
     env:
       OS_NAME: 'linux'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,12 @@ on:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ${{ matrix.image }}
+    container: 
+      image: ${{ matrix.image }}
+      env:
+        OS_NAME: 'linux'
+        VSCODE_ARCH: ${{ matrix.vscode_arch }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -26,10 +31,6 @@ jobs:
           npm_arch: armv7l
           image: vscodium/vscodium-linux-build-agent:buster-armhf
 
-    env:
-      OS_NAME: 'linux'
-      VSCODE_ARCH: ${{ matrix.vscode_arch }}
-
     steps:
       - uses: actions/checkout@v2
 
@@ -37,6 +38,11 @@ jobs:
         uses: actions/setup-node@v1.4.3
         with:
           node-version: 12.14.1
+
+      - name: Debug
+        run: |
+          ls -al
+          ls /__w
 
       - name: Clone VSCode repo
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
         - vscode_arch: arm64
           npm_arch: arm64
           image: vscodium/vscodium-linux-build-agent:buster-arm64
-        - vscode_arch: armhf
+        - vscode_arch: arm
           npm_arch: armv7l
           image: vscodium/vscodium-linux-build-agent:buster-armhf
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
   echo "LATEST_MS_COMMIT: ${LATEST_MS_COMMIT}"
   echo "BUILD_SOURCEVERSION: ${BUILD_SOURCEVERSION}"
 
-  if [[ "$OS_NAME" != "osx" ]]; then
+  if [[ "$CI_WINDOWS" == "True" ]]; then
     export npm_config_arch="$BUILDARCH"
     export npm_config_target_arch="$BUILDARCH"
   fi
@@ -36,12 +36,10 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     yarn gulp "vscode-win32-${BUILDARCH}-system-setup"
     yarn gulp "vscode-win32-${BUILDARCH}-user-setup"
   else # linux
-    yarn gulp vscode-linux-${BUILDARCH}-min-ci
+    yarn gulp vscode-linux-${VSCODE_ARCH}-min-ci
 
-    yarn gulp "vscode-linux-${BUILDARCH}-build-deb"
-    if [[ "$BUILDARCH" == "x64" ]]; then
-      yarn gulp "vscode-linux-${BUILDARCH}-build-rpm"
-    fi
+    yarn gulp "vscode-linux-${VSCODE_ARCH}-build-deb"
+    yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
     . ../create_appimage.sh
   fi
 

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,10 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     yarn gulp vscode-linux-${VSCODE_ARCH}-min-ci
 
     yarn gulp "vscode-linux-${VSCODE_ARCH}-build-deb"
-    yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
+
+    if [[ "$VSCODE_ARCH" == "x64" ]]; then
+      yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
+    fi
     . ../create_appimage.sh
   fi
 

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -29,7 +29,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
         echo "Already have all the Linux arm64 builds"
       fi
-    elif [[ $VSCODE_ARCH == "armhf" ]]; then
+    elif [[ $VSCODE_ARCH == "arm" ]]; then
       HAVE_ARM_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["armhf.deb"])')
       HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
       if [[ "$HAVE_ARM_DEB" != "true" ]]; then

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -69,3 +69,4 @@ if [ "$GITHUB_TOKEN" != "" ]; then
   fi
 fi
 
+echo "SHOULD_BUILD=$SHOULD_BUILD" >> $GITHUB_ENV

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -15,7 +15,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
         echo "Building on Mac because we have no ZIP"
         export SHOULD_BUILD="yes"
       fi
-    elif [[ $BUILDARCH == "arm64" ]]; then
+    elif [[ $VSCODE_ARCH == "arm64" ]]; then
       HAVE_ARM64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.deb"])')
       HAVE_ARM64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
       if [[ "$HAVE_ARM64_DEB" != "true" ]]; then
@@ -29,7 +29,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
         echo "Already have all the Linux arm64 builds"
       fi
-    elif [[ $BUILDARCH == "arm" ]]; then
+    elif [[ $VSCODE_ARCH == "armhf" ]]; then
       HAVE_ARM_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["armhf.deb"])')
       HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
       if [[ "$HAVE_ARM_DEB" != "true" ]]; then

--- a/create_appimage.sh
+++ b/create_appimage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ "$BUILDARCH" == "x64" ]]; then
+if [[ "$VSCODE_ARCH" == "x64" ]]; then
   # install a dep needed for this process
   sudo apt-get install desktop-file-utils
 

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -8,3 +8,6 @@ echo "Got the latest MS tag: ${LATEST_MS_TAG}"
 
 git clone https://github.com/Microsoft/vscode.git --branch $LATEST_MS_TAG --depth 1
 
+echo "LATEST_MS_COMMIT=$LATEST_MS_COMMIT" >> $GITHUB_ENV
+echo "LATEST_MS_TAG=$LATEST_MS_TAG" >> $GITHUB_ENV
+

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -8,6 +8,9 @@ echo "Got the latest MS tag: ${LATEST_MS_TAG}"
 
 git clone https://github.com/Microsoft/vscode.git --branch $LATEST_MS_TAG --depth 1
 
-echo "LATEST_MS_COMMIT=$LATEST_MS_COMMIT" >> $GITHUB_ENV
-echo "LATEST_MS_TAG=$LATEST_MS_TAG" >> $GITHUB_ENV
+# for GH actions
+if [[ "$CI_WINDOWS" != "True" ]]; then
+  echo "LATEST_MS_COMMIT=$LATEST_MS_COMMIT" >> $GITHUB_ENV
+  echo "LATEST_MS_TAG=$LATEST_MS_TAG" >> $GITHUB_ENV
+fi
 

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ "$OS_NAME" != "osx" ]]; then
+if [[ "$CI_WINDOWS" == "True" ]]; then
   export npm_config_arch="$BUILDARCH"
   export npm_config_target_arch="$BUILDARCH"
 fi
@@ -21,13 +21,6 @@ if [[ "$OS_NAME" == "osx" ]]; then
 else
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile
   yarn postinstall
-fi
-
-if [[ "$BUILDARCH" == *"arm"* ]]; then
-  sed -i -z 's/,\n[^\n]*arm[^\n]*//' node_modules/vscode-sqlite3/binding.gyp
-  sed -i "s/Release\/sqlite'/Release\/sqlite.node'/" node_modules/vscode-sqlite3/lib/sqlite3.js
-  yarn add -D electron-rebuild
-  npx electron-rebuild -f -w vscode-sqlite3
 fi
 
 mv product.json product.json.bak

--- a/update_version.sh
+++ b/update_version.sh
@@ -125,8 +125,8 @@ else # linux
   # update service links to tar.gz file
   # see https://update.code.visualstudio.com/api/update/linux-x64/stable/VERSION
   # as examples
-  ASSET_NAME=VSCodium-linux-${BUILDARCH}-${LATEST_MS_TAG}.tar.gz
-  VERSION_PATH="linux/${BUILDARCH}"
+  ASSET_NAME=VSCodium-linux-${VSCODE_ARCH}-${LATEST_MS_TAG}.tar.gz
+  VERSION_PATH="linux/${VSCODE_ARCH}"
   JSON="$(generateJson ${ASSET_NAME})"
   updateLatestVersion "$VERSION_PATH" "$JSON"
 fi


### PR DESCRIPTION
Turns out MS is maintaining docker images for Linux build environments, so have [forked those](https://github.com/VSCodium/vscode-linux-build-agent) and made them public: https://hub.docker.com/repository/docker/vscodium/vscodium-linux-build-agent

RPM for arm is busted until [this commit upstream](https://github.com/microsoft/vscode/commit/034f6fc5ba9f0f00983f2aeb559af411b2fb22e5) is released. Included in the next release will most likely also be [this commit](https://github.com/microsoft/vscode/commit/47d8a2560605b5b6b013719f7f385ec9750cae9f) which renames the gulp task for armhf builds; so I expect the need for a patch on next release to make armhf build here.

Should fix #520 