### PR TITLE
Fix armhf and x64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vscode_arch: [x64, arm64, arm]
+        vscode_arch: [x64, arm64, armhf]
         include:
         - vscode_arch: x64
           npm_arch: x64
@@ -27,7 +27,7 @@ jobs:
         - vscode_arch: arm64
           npm_arch: arm64
           image: vscodium/vscodium-linux-build-agent:buster-arm64
-        - vscode_arch: arm
+        - vscode_arch: armhf
           npm_arch: armv7l
           image: vscodium/vscodium-linux-build-agent:buster-armhf
 

--- a/build.sh
+++ b/build.sh
@@ -36,13 +36,9 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     yarn gulp "vscode-win32-${BUILDARCH}-system-setup"
     yarn gulp "vscode-win32-${BUILDARCH}-user-setup"
   else # linux
-    yarn gulp vscode-linux-${VSCODE_ARCH}-min-ci
-
+    yarn gulp "vscode-linux-${VSCODE_ARCH}-min-ci"
     yarn gulp "vscode-linux-${VSCODE_ARCH}-build-deb"
-
-    if [[ "$VSCODE_ARCH" == "x64" ]]; then
-      yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
-    fi
+    yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
     . ../create_appimage.sh
   fi
 

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -29,9 +29,9 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       if [[ "$SHOULD_BUILD" != "yes" ]]; then
         echo "Already have all the Linux arm64 builds"
       fi
-    elif [[ $VSCODE_ARCH == "arm" ]]; then
+    elif [[ $VSCODE_ARCH == "armhf" ]]; then
       HAVE_ARM_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["armhf.deb"])')
-      HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+      HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "armhf-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
       if [[ "$HAVE_ARM_DEB" != "true" ]]; then
         echo "Building on Linux arm because we have no DEB"
         export SHOULD_BUILD="yes"

--- a/create_appimage.sh
+++ b/create_appimage.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-if [[ "$VSCODE_ARCH" == "x64" ]]; then
-  # install a dep needed for this process
-  sudo apt-get install desktop-file-utils
-
-  cd ..
-  
-  bash -e src/resources/linux/appimage/pkg2appimage VSCodium-AppImage-Recipe.yml
-fi
+# if [[ "$VSCODE_ARCH" == "x64" ]]; then
+#   # install a dep needed for this process
+#   sudo apt-get install desktop-file-utils
+# 
+#   cd ..
+#   
+#   bash -e src/resources/linux/appimage/pkg2appimage VSCodium-AppImage-Recipe.yml
+# fi


### PR DESCRIPTION
x64 builds were broken due to missing dependency (`convert`); I added that to the build environment (https://github.com/VSCodium/vscode-linux-build-agent/commit/e146653aa186ff2bc2a2dae7c5297beb6c11e802), but AppImage creation is broken for Docker-specific reasons. I will open an issue to track that and get some help from people who know more about AppImages.

For now this should get the deb/rpms for x64 and armhf for latest release back to working state.