### PR TITLE
Custom extensions gallery

### DIFF
--- a/patches/custom-extensions-gallery.patch
+++ b/patches/custom-extensions-gallery.patch
@@ -1,0 +1,28 @@
+diff --git a/src/vs/platform/product/common/product.ts b/src/vs/platform/product/common/product.ts
+index 2bea85740c..d0e9da036c 100644
+--- a/src/vs/platform/product/common/product.ts
++++ b/src/vs/platform/product/common/product.ts
+@@ -57,6 +57,23 @@ else {
+ 		});
+ 	}
+ 
++	// Set user-defined extension gallery
++	if (
++		env['VSCODIUM_EXTENSIONS_GALLERY_SERVICE_URL']
++		|| env['VSCODIUM_EXTENSIONS_GALLERY_ITEM_URL']
++		|| env['VSCODIUM_EXTENSIONS_GALLERY_CONTROL_URL']
++		|| env['VSCODIUM_EXTENSIONS_GALLERY_RECOMMENDATIONS_URL']
++	) {
++		Object.assign(product, {
++			extensionsGallery: {
++				serviceUrl: env['VSCODIUM_EXTENSIONS_GALLERY_SERVICE_URL'],
++				itemUrl: env['VSCODIUM_EXTENSIONS_GALLERY_ITEM_URL'],
++				controlUrl: env['VSCODIUM_EXTENSIONS_GALLERY_CONTROL_URL'],
++				recommendationsUrl: env['VSCODIUM_EXTENSIONS_GALLERY_RECOMMENDATIONS_URL']
++			}
++		})
++	}
++
+ 	Object.assign(product, {
+ 		version: pkg.version
+ 	});

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -13,6 +13,7 @@ cd vscode || exit
 ../update_settings.sh
 
 # apply patches
+patch -u src/vs/platform/product/common/product.ts -i ../patches/custom-extensions-gallery.patch
 patch -u src/vs/platform/update/electron-main/updateService.win32.ts -i ../patches/update-cache-path.patch
 
 if [[ "$OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
This pull request lets VSCodium accept 4 optional environment variables:
* `VSCODIUM_EXTENSIONS_GALLERY_SERVICE_URL`
* `VSCODIUM_EXTENSIONS_GALLERY_ITEM_URL`
* `VSCODIUM_EXTENSIONS_GALLERY_CONTROL_URL`
* `VSCODIUM_EXTENSIONS_GALLERY_RECOMMENDATIONS_URL`

If defined, these environment variables allow VSCodium to use a marketplace other than the default marketplace specified in [prepare_vscode.sh](https://github.com/VSCodium/vscodium/blob/master/prepare_vscode.sh) (currently [Open VSX](https://github.com/eclipse/openvsx)). In particular, they enable users to select the [Visual Studio Marketplace](https://marketplace.visualstudio.com/) with the `serviceUrl` and `itemUrl` values provided in microsoft/vscode#31168 (published under the MIT License in microsoft/vscode@b00945fc8c79f6db74b280ef53eba060ed9a1388).

I was able to build VSCodium with the changes in this pull request using the discussion in #272 as a guide, and I can confirm that the built VSCodium AppImage is able to access the Visual Studio Marketplace with `VSCODIUM_EXTENSIONS_GALLERY_SERVICE_URL` and `VSCODIUM_EXTENSIONS_GALLERY_ITEM_URL` set to the correct values.

This pull request is based on the interfaces defined in [productService.ts](https://github.com/microsoft/vscode/blob/master/src/vs/platform/product/common/productService.ts), and is inspired by flathub/com.visualstudio.code-oss@f4fb6f33f410a59a04a5b564792e024b524fd2cc (explained in flathub/com.visualstudio.code-oss#11) from the ["Code - OSS" Flatpak](https://github.com/flathub/com.visualstudio.code-oss).

Resolves #519.