### PR TITLE
Small (backwards compatible) change to make the Arch Linux AUR build of vscodium easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ snap install codium
 You can always install using the downloads (deb, rpm, tar) on the [releases page](https://github.com/VSCodium/vscodium/releases), but you can also install using your favorite package manager and get automatic updates. [@paulcarroty](https://github.com/paulcarroty) has set up a repository with instructions [here](https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo). Any issues installing VSCodium using your package manager should be directed to that repository's issue tracker. 
 
 #### <a id="install-on-arch-linux"></a>Install on Arch Linux
-VSCodium is available in [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) as package [vscodium-bin](https://aur.archlinux.org/packages/vscodium-bin/), maintained by [@CRKatri](https://github.com/CRKatri).
+VSCodium is available in [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) as package [vscodium-bin](https://aur.archlinux.org/packages/vscodium-bin/), maintained by [@CRKatri](https://github.com/CRKatri). An alternative package [vscodium-git](https://aur.archlinux.org/packages/vscodium-git/), maintained by [@cedricroijakkers](https://github.com/cedricroijakkers), is also available should you wish to compile from source yourself.
 
 #### <a id="flatpak"></a>Flatpak Option (Linux)
 VSCodium is (unofficially) available as a Flatpak app [here](https://flathub.org/apps/details/com.vscodium.codium) and the build repo is [here](https://github.com/flathub/com.vscodium.codium). If your distribution has support for [flatpak](https://flathub.org), and you have enabled the [flathub repo](https://flatpak.org/setup/):

--- a/build.sh
+++ b/build.sh
@@ -37,9 +37,11 @@ if [[ "$SHOULD_BUILD" == "yes" ]]; then
     yarn gulp "vscode-win32-${BUILDARCH}-user-setup"
   else # linux
     yarn gulp "vscode-linux-${VSCODE_ARCH}-min-ci"
-    yarn gulp "vscode-linux-${VSCODE_ARCH}-build-deb"
-    yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
-    . ../create_appimage.sh
+    if [[ "$SKIP_LINUX_PACKAGES" != "True" ]]; then
+      yarn gulp "vscode-linux-${VSCODE_ARCH}-build-deb"
+      yarn gulp "vscode-linux-${VSCODE_ARCH}-build-rpm"
+      . ../create_appimage.sh
+    fi
   fi
 
   cd ..


### PR DESCRIPTION
Hi!

I'm the maintainer of the Arch Linux AUR package [vscodium-git](https://aur.archlinux.org/packages/vscodium-git/), which is an alternative to the already documented [vscodium-bin](https://aur.archlinux.org/packages/vscodium-bin/) but for people with Arch (or any of its derivatives like Manjaro) that wish to compile their packages themselves (kinda like Gentoo). It's normal in the AUR to have from-binaries and from-source releases for many packages.

I've created this pull request for two reasons:

1. Added the link to the vscodium-git to the `README.md` for those who would like to install it.
2. Added an environment variable `SKIP_LINUX_PACKAGES` in the `build.sh` that I can use in the AUR package build script.

In the AUR build script, there is no need to build the `rpm`, `deb`, or `AppImage` packages of VSCodium, since Arch does not use these packages at all. Even worse, I do not wish to force users to install the necessary build tooling needed to create those packages, since they will not be used anyway, and would only make the compilation take more time, only to be thrown away after the build. Right now, I've included a small patch that removes these lines from the `build.sh` script before starting the build. Since this creates an unneeded dependency on the `build.sh` script, and I need to check it every time for changes when a new version of VSCodium is released and update the patch, I've created this pull request to set a simple environment variable to skip the creation of the packages. By default, the environment variable is not set and the packages will be created, so the pull request is fully backwards compatible. The envrionment variable will be set in the AUR build process and will nicely skip the unneeded steps.

Please let me know if you have thoughts or better ways to accomplish this, as I would gladly update my pull request to make everyone's life easier.