### PR TITLE
Add note about VSCodium update API to "Getting all the Telemetry Out"

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -26,9 +26,11 @@ It is also highly recommended that you review all the settings that "use online 
 
 These can all be disabled.
 
-__Please note that some extensions send telemetry data to Microsoft as well. We have no control over this and can only recommend removing the extension.__
+__Please note that some extensions send telemetry data to Microsoft as well. We have no control over this and can only recommend removing the extension.__ _(For example, the C# extension `ms-vscode.csharp` sends tracking data to Microsoft.)_
 
-_(For example the C# extension `ms-vscode.csharp` sends tracking data to Microsoft.)_
+### VSCodium Update API
+
+When searching the `@tag:usesOnlineServices` filter, note that while the "Update: Mode" setting description still says "The updates are fetched from a Microsoft online service", VSCodium's [build script sets](https://github.com/VSCodium/vscodium/blob/master/prepare_vscode.sh#L36) the `updateUrl` field in `product.json` to that of VSCodium's own small [update server](https://github.com/VSCodium/update-api), so enabling that setting won't actually result in any calls to Microsoft servers.
 
 ## <a id="extensions-marketplace"></a>Extensions + Marketplace
 


### PR DESCRIPTION
Not too long after switching from VS Code, I saw a software update available within VSCodium and downloaded and applied the update without thinking. Later, I was perusing [Getting all the Telemetry Out](https://github.com/VSCodium/vscodium/blob/5ffd1aa4b0f59d51d37be6eeb0d8830bd6c42a40/DOCS.md#getting-all-the-telemetry-out), learned about the `@tag:usesOnlineServices` settings filter, tried using the filter in my own settings, and saw in the description for the `update.mode` setting, "The updates are fetched from a Microsoft online service."

That very much confused me, since I thought it meant that when I had used the internal software update function in VSCodium it had actually fetched those updates from Microsoft instead of from this repository. I remained confused until I happened upon #533, which led me to the [update-api](https://github.com/VSCodium/update-api) repo, which pointed me to #41 and the [Auto Update Support](https://github.com/VSCodium/vscodium/projects/1) project, and I finally understood.

So this PR is a little addition to "Getting all the Telemetry Out" that explains the update API in light of the `update.mode` setting description to hopefully prevent further confusion.

Here's the new text, starting with a new subheading within the "Getting all the Telemetry Out" section:

> ### VSCodium Update API
>
> When searching the `@tag:usesOnlineServices` filter, note that while the "Update: Mode" setting description still says "The updates are fetched from a Microsoft online service", VSCodium's [build script sets](https://github.com/VSCodium/vscodium/blob/master/prepare_vscode.sh#L36) the `updateUrl` field in `product.json` to that of VSCodium's own small [update server](https://github.com/VSCodium/update-api), so enabling that setting won't actually result in any calls to Microsoft servers.