### PR TITLE
Don't replace product.json in RPM updates

### DIFF
--- a/patches/no-replace-product-json.patch
+++ b/patches/no-replace-product-json.patch
@@ -1,0 +1,8 @@
+--- vscode/resources/linux/rpm/code.spec.template	2020-11-15 15:28:20.179070106 +0800
++++ vscode/resources/linux/rpm/code.spec.template.new	2020-11-15 15:25:39.269000000 +0800
+@@ -69,3 +69,5 @@
+ /usr/share/pixmaps/@@ICON@@.png
+ /usr/share/bash-completion/completions/@@NAME@@
+ /usr/share/zsh/site-functions/_@@NAME@@
++
++%config(noreplace) /usr/share/@@NAME@@/resources/app/product.json

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -14,6 +14,7 @@ cd vscode || exit
 
 # apply patches
 patch -u src/vs/platform/update/electron-main/updateService.win32.ts -i ../patches/update-cache-path.patch
+patch -u resources/linux/rpm/code.spec.template -i ../patches/no-replace-product-json.patch
 
 if [[ "$OS_NAME" == "osx" ]]; then
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile --ignore-optional


### PR DESCRIPTION
If product.json is modified locally, say, to change gallery url, in each updates, the product.json is replaced by the vanilla one, which makes some troubles. This patch prevents that issue in RPM builds by marking `noreplace` on it. Not sure whether other packaging formats have similiar feature.