### PR TITLE
Fix actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1.4.3
+        uses: actions/setup-node@v1
         with:
           node-version: 12.14.1
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,15 +23,12 @@ jobs:
       - name: Clone VSCode repo
         run: |
           . get_repo.sh
-          echo "::set-env name=LATEST_MS_TAG::$LATEST_MS_TAG"
-          echo "::set-env name=LATEST_MS_COMMIT::$LATEST_MS_COMMIT"
 
       - name: Check existing VSCodium tags/releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . check_tags.sh
-          echo "::set-env name=SHOULD_BUILD::$SHOULD_BUILD"
           
       - name: Build
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1.4.3
+        uses: actions/setup-node@v1
         with:
           node-version: 12.14.1
           


### PR DESCRIPTION
GitHub now enforcing no `set-env` or `add-path` calls: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

The `set-env` calls in macos.yml were already redundant; we were doing the new way (`echo "key=val" >> $GITHUB_ENV`) in `check_tags.sh` and `get_repo.sh`. 

`actions/setup-node` updated to env files in 1.4.4, but our workflow was locked at 1.4.3. Removed the spec lock to pick up the latest minor versions going forward.