### PR TITLE
Update update-cache-path.patch

### DIFF
--- a/patches/update-cache-path.patch
+++ b/patches/update-cache-path.patch
@@ -1,11 +1,11 @@
---- vscode/src/vs/platform/update/electron-main/updateService.win32.ts	2019-12-08 15:09:44.000000000 -0800
-+++ src/src/vs/platform/update/electron-main/updateService.win32.ts	2019-12-08 15:12:56.000000000 -0800
+--- vscode/src/vs/platform/update/electron-main/updateService.win32.ts	2021-02-05 11:59:17.564060663 -0600
++++ src/src/vs/platform/update/electron-main/updateService.win32.ts	2021-02-05 11:59:39.780745778 -0600
 @@ -55,7 +55,7 @@
  
  	@memoize
  	get cachePath(): Promise<string> {
 -		const result = path.join(tmpdir(), `vscode-update-${product.target}-${process.arch}`);
 +		const result = path.join(tmpdir(), `vscodium-update-${product.target}-${process.arch}`);
- 		return pfs.mkdirp(result, undefined).then(() => result);
+ 		return pfs.mkdirp(result).then(() => result);
  	}
  


### PR DESCRIPTION
Fixes patch error during build.

There are [additional changes to the updateService.win32.ts file](https://github.com/microsoft/vscode/commits/master/src/vs/platform/update/electron-main/updateService.win32.ts) in the master branch since the 1.53.0 tag that will need to be fixed fot the next update as well.