### PR TITLE
Update Linux build agents

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,13 +23,13 @@ jobs:
         include:
         - vscode_arch: x64
           npm_arch: x64
-          image: vscodium/vscodium-linux-build-agent:x64
+          image: vscodium/vscodium-linux-build-agent:bionic-x64
         - vscode_arch: arm64
           npm_arch: arm64
-          image: vscodium/vscodium-linux-build-agent:buster-arm64
+          image: vscodium/vscodium-linux-build-agent:stretch-arm64
         - vscode_arch: armhf
           npm_arch: armv7l
-          image: vscodium/vscodium-linux-build-agent:buster-armhf
+          image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,16 +32,6 @@ jobs:
           image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
-      - name: Get Actions user id
-        id: get_uid
-        run: |
-          actions_user_id=`id -u $USER`
-          echo $actions_user_id
-          echo ::set-output name=uid::$actions_user_id
-      - name: Correct Ownership in GITHUB_WORKSPACE directory
-        uses: peter-murray/reset-workspace-ownership-action@v1
-        with:
-          user_id: ${{ steps.get_uid.outputs.uid }}
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,6 +32,16 @@ jobs:
           image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
+      - name: Get Actions user id
+        id: get_uid
+        run: |
+          actions_user_id=`id -u $USER`
+          echo $actions_user_id
+          echo ::set-output name=uid::$actions_user_id
+      - name: Correct Ownership in GITHUB_WORKSPACE directory
+        uses: peter-murray/reset-workspace-ownership-action@v1
+        with:
+          user_id: ${{ steps.get_uid.outputs.uid }}
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment


### PR DESCRIPTION
MS updated the build agents themselves, so I applied those updates to the vscodium build agents repo (https://github.com/VSCodium/vscode-linux-build-agent). MS also is now using stretch for Linux arm builds and bionic for the x64 build. Slight issue with Github Actions not playing nice with containers that don't use root (😢) but now Linux artifacts are being created.

Closes #630
Closes #632 