### PR TITLE
Remove redundant `yarn postinstall` call

### DIFF
--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -16,7 +16,6 @@ if [[ "$OS_NAME" == "osx" ]]; then
   npm_config_argv='{"original":["--ignore-optional"]}' yarn postinstall
 else
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile
-  yarn postinstall
 fi
 
 mv product.json product.json.bak


### PR DESCRIPTION
`yarn postinstall` is automatically run after `yarn install`, so this explicit call is not necessary.

Removing it saves around 10 to 20 seconds in the build job ([Linux](https://github.com/VSCodium/vscodium/runs/1883768900?check_suite_focus=true#step:8:597), [macOS](https://github.com/VSCodium/vscodium/runs/1883686772?check_suite_focus=true#step:6:579), [Windows](https://github.com/VSCodium/vscodium/runs/1883728672?check_suite_focus=true#step:8:589) logs for reference).