### PR TITLE
patch static binary name

### DIFF
--- a/build/build_windows.ps1
+++ b/build/build_windows.ps1
@@ -1,9 +1,8 @@
-# powershell -ExecutionPolicy ByPass -File build_windows.ps1
+# powershell -ExecutionPolicy ByPass -File .\build\build_windows.ps1
 
 $env:Path += ";C:\Program Files\Git\bin"
 
 Remove-Item -Recurse -Force VSCode*
-Remove-Item -Recurse -Force vscode
 
 bash ./get_repo.sh
 

--- a/patches/binary-name.patch
+++ b/patches/binary-name.patch
@@ -24,15 +24,12 @@ diff --git a/src/vs/platform/native/electron-main/nativeHostMainService.ts b/src
 index 50c4460..bf73260 100644
 --- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
 +++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
-@@ -430,7 +430,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
- 
+@@ -431,4 +431,4 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
  		// macOS
- 		if (this.environmentService.isBuilt) {
--			return join(this.environmentService.appRoot, 'bin', 'code');
-+			return join(this.environmentService.appRoot, 'bin', `${product.applicationName}`);
+ 		if (this.environmentMainService.isBuilt) {
+-			return join(this.environmentMainService.appRoot, 'bin', 'code');
++			return join(this.environmentMainService.appRoot, 'bin', `${product.applicationName}`);
  		}
- 
- 		return join(this.environmentService.appRoot, 'scripts', 'code-cli.sh');
 diff --git a/src/vs/workbench/contrib/cli/node/cli.contribution.ts b/src/vs/workbench/contrib/cli/node/cli.contribution.ts
 index 30972a4..0a9435c 100644
 --- a/src/vs/workbench/contrib/cli/node/cli.contribution.ts

--- a/patches/binary-name.patch
+++ b/patches/binary-name.patch
@@ -1,0 +1,48 @@
+diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
+index 6d3a369..57009d4 100644
+--- a/build/gulpfile.vscode.js
++++ b/build/gulpfile.vscode.js
+@@ -276,7 +276,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
+ 			all = es.merge(all, gulp.src('resources/linux/code.png', { base: '.' }));
+ 		} else if (platform === 'darwin') {
+ 			const shortcut = gulp.src('resources/darwin/bin/code.sh')
+-				.pipe(rename('bin/code'));
++				.pipe(rename('bin/' + product.applicationName));
+ 
+ 			all = es.merge(all, shortcut);
+ 		}
+@@ -483,7 +483,7 @@ const generateVSCodeConfigurationTask = task.define('generate-vscode-configurati
+ 		const arch = process.env['VSCODE_ARCH'];
+ 		const appRoot = path.join(buildDir, `VSCode-darwin-${arch}`);
+ 		const appName = process.env.VSCODE_QUALITY === 'insider' ? 'Visual\\ Studio\\ Code\\ -\\ Insiders.app' : 'Visual\\ Studio\\ Code.app';
+-		const appPath = path.join(appRoot, appName, 'Contents', 'Resources', 'app', 'bin', 'code');
++		const appPath = path.join(appRoot, appName, 'Contents', 'Resources', 'app', 'bin', product.applicationName);
+ 		const codeProc = cp.exec(
+ 			`${appPath} --export-default-configuration='${allConfigDetailsPath}' --wait --user-data-dir='${userDataDir}' --extensions-dir='${extensionsDir}'`,
+ 			(err, stdout, stderr) => {
+diff --git a/src/vs/platform/native/electron-main/nativeHostMainService.ts b/src/vs/platform/native/electron-main/nativeHostMainService.ts
+index 50c4460..bf73260 100644
+--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
++++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
+@@ -430,7 +430,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
+ 
+ 		// macOS
+ 		if (this.environmentService.isBuilt) {
+-			return join(this.environmentService.appRoot, 'bin', 'code');
++			return join(this.environmentService.appRoot, 'bin', `${product.applicationName}`);
+ 		}
+ 
+ 		return join(this.environmentService.appRoot, 'scripts', 'code-cli.sh');
+diff --git a/src/vs/workbench/contrib/cli/node/cli.contribution.ts b/src/vs/workbench/contrib/cli/node/cli.contribution.ts
+index 30972a4..0a9435c 100644
+--- a/src/vs/workbench/contrib/cli/node/cli.contribution.ts
++++ b/src/vs/workbench/contrib/cli/node/cli.contribution.ts
+@@ -29,7 +29,7 @@ let _source: string | null = null;
+ function getSource(): string {
+ 	if (!_source) {
+ 		const root = FileAccess.asFileUri('', require).fsPath;
+-		_source = path.resolve(root, '..', 'bin', 'code');
++		_source = path.resolve(root, '..', 'bin', product.applicationName);
+ 	}
+ 	return _source;
+ }

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -10,7 +10,7 @@ cd vscode || exit
 # apply patches
 patch -u src/vs/platform/update/electron-main/updateService.win32.ts -i ../patches/update-cache-path.patch
 patch -u resources/linux/rpm/code.spec.template -i ../patches/fix-rpm-spec.patch
-git apply ../patches/binary-name.patch
+git apply --ignore-whitespace ../patches/binary-name.patch
 
 if [[ "$OS_NAME" == "osx" ]]; then
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile --ignore-optional

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -10,6 +10,7 @@ cd vscode || exit
 # apply patches
 patch -u src/vs/platform/update/electron-main/updateService.win32.ts -i ../patches/update-cache-path.patch
 patch -u resources/linux/rpm/code.spec.template -i ../patches/no-replace-product-json.patch
+git apply ../patches/binary-name.patch
 
 if [[ "$OS_NAME" == "osx" ]]; then
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile --ignore-optional


### PR DESCRIPTION
This PR is patching the binary name to use `product.applicationName` instead of being static.

It should fix #509.

For #654, it needs further informations.