### PR TITLE
Fix a typo (VSCode -> VS Code) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <br />
     <img src="./src/resources/linux/code.png" alt="VSCodium Logo" width="200"/>
     <h1>VSCodium</h1>
-    <h3>Free/Libre Open Source Software Binaries of VSCode</h3>
+    <h3>Free/Libre Open Source Software Binaries of VS Code</h3>
 </div>
 
 <div id="badges" align="center">
@@ -86,7 +86,7 @@ flatpak run com.vscodium.codium
 ```
 
 ## <a id="why"></a>Why Does This Exist
-This repository contains build files to generate free release binaries of Microsoft's VSCode. When we speak of "free software", we're talking about freedom, not price.
+This repository contains build files to generate free release binaries of Microsoft's VS Code. When we speak of "free software", we're talking about freedom, not price.
 
 Microsoft's releases of Visual Studio Code are licensed under [this not-FLOSS license](https://code.visualstudio.com/license) and contain telemetry/tracking. According to [this comment](https://github.com/Microsoft/vscode/issues/60#issuecomment-161792005) from a Visual Studio Code maintainer: 
 
@@ -96,7 +96,7 @@ Microsoft's releases of Visual Studio Code are licensed under [this not-FLOSS li
 
 This repo exists so that you don't have to download+build from source. The build scripts in this repo clone Microsoft's vscode repo, run the build commands, and upload the resulting binaries to [GitHub releases](https://github.com/VSCodium/vscodium/releases). __These binaries are licensed under the MIT license. Telemetry is disabled.__
 
-If you want to build from source yourself, head over to [Microsoft's vscode repo](https://github.com/Microsoft/vscode) and follow their [instructions](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#build-and-run). This repo exists to make it easier to get the latest version of MIT-licensed VSCode.
+If you want to build from source yourself, head over to [Microsoft's vscode repo](https://github.com/Microsoft/vscode) and follow their [instructions](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#build-and-run). This repo exists to make it easier to get the latest version of MIT-licensed VS Code.
 
 Microsoft's build process (which we are running to build the binaries) does download additional files. This was brought up in [Microsoft/vscode#49159](https://github.com/Microsoft/vscode/issues/49159) and [Microsoft/vscode#45978](https://github.com/Microsoft/vscode/issues/45978). These are the packages downloaded during build:
 


### PR DESCRIPTION
Repository description and ["Extensions and the Marketplace"](https://github.com/VSCodium/vscodium#extensions-and-the-marketplace) `README.md` paragraph refers to the upstream editor as "VS Code", while other parts of the README refer to it as "VSCode".

Upstream refers to it as "VS Code" (for example, see https://github.com/microsoft/vscode#related-projects). This commit makes the README file consistently use that specific spelling.