### PR TITLE
remove Centos 7 compatibility

### DIFF
--- a/patches/fix-rpm-spec.patch
+++ b/patches/fix-rpm-spec.patch
@@ -1,0 +1,16 @@
+--- vscode/resources/linux/rpm/code.spec.template	2021-03-02 19:26:53.000000000 +0100
++++ vscode/resources/linux/rpm/code.spec.template.new	2021-03-02 19:28:12.000000000 +0100
+@@ -1,6 +1,6 @@
+ Name:     @@NAME@@
+ Version:  @@VERSION@@
+-Release:  @@RELEASE@@.el7
++Release:  @@RELEASE@@.el8
+ Summary:  Code editing. Redefined.
+ Group:    Development/Tools
+ Vendor:   Microsoft Corporation
+@@ -69,3 +69,5 @@
+ /usr/share/pixmaps/@@ICON@@.png
+ /usr/share/bash-completion/completions/@@NAME@@
+ /usr/share/zsh/site-functions/_@@NAME@@
++
+++%config(noreplace) /usr/share/@@NAME@@/resources/app/product.json

--- a/patches/no-replace-product-json.patch
+++ b/patches/no-replace-product-json.patch
@@ -1,8 +1,0 @@
---- vscode/resources/linux/rpm/code.spec.template	2020-11-15 15:28:20.179070106 +0800
-+++ vscode/resources/linux/rpm/code.spec.template.new	2020-11-15 15:25:39.269000000 +0800
-@@ -69,3 +69,5 @@
- /usr/share/pixmaps/@@ICON@@.png
- /usr/share/bash-completion/completions/@@NAME@@
- /usr/share/zsh/site-functions/_@@NAME@@
-+
-+%config(noreplace) /usr/share/@@NAME@@/resources/app/product.json

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -9,7 +9,7 @@ cd vscode || exit
 
 # apply patches
 patch -u src/vs/platform/update/electron-main/updateService.win32.ts -i ../patches/update-cache-path.patch
-patch -u resources/linux/rpm/code.spec.template -i ../patches/no-replace-product-json.patch
+patch -u resources/linux/rpm/code.spec.template -i ../patches/fix-rpm-spec.patch
 
 if [[ "$OS_NAME" == "osx" ]]; then
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile --ignore-optional


### PR DESCRIPTION
This PR is removing the compatibility for Centos 7 since it isn't supported by Electron 11 (https://code.visualstudio.com/updates/v1_53#_electron-11-update).