### PR TITLE
Reduce context for `patches/update-cache-path.patch`

### DIFF
--- a/patches/update-cache-path.patch
+++ b/patches/update-cache-path.patch
@@ -1,11 +1,7 @@
 --- vscode/src/vs/platform/update/electron-main/updateService.win32.ts	2021-02-05 11:59:17.564060663 -0600
 +++ src/src/vs/platform/update/electron-main/updateService.win32.ts	2021-02-05 11:59:39.780745778 -0600
-@@ -55,7 +55,7 @@
- 
+@@ -56,3 +56,3 @@
  	@memoize
  	get cachePath(): Promise<string> {
 -		const result = path.join(tmpdir(), `vscode-update-${product.target}-${process.arch}`);
 +		const result = path.join(tmpdir(), `vscodium-update-${product.target}-${process.arch}`);
- 		return pfs.mkdirp(result).then(() => result);
- 	}
- 


### PR DESCRIPTION
Upstream changed the next line, causing build breakage. Reducing the context resolves the issue and should help prevent future issues if/when that function changes again.

Examples of failing builds this should fix (though I have only tested Linux):
- https://github.com/VSCodium/vscodium/actions/runs/630661540
- https://github.com/VSCodium/vscodium/actions/runs/630646856
- https://github.com/VSCodium/vscodium/actions/runs/630631432

This should unblock releasing 1.54.0 and 1.54.1, which were released upstream late last week.