### PR TITLE
fix schedule runs

### DIFF
--- a/check_cron_or_pr.sh
+++ b/check_cron_or_pr.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ $github.event.number ]]; then
+if [[ $github.event_name == "pull_request" ]]; then
 	echo "It's a PR"
 	
 	export SHOULD_BUILD="yes"

--- a/check_cron_or_pr.sh
+++ b/check_cron_or_pr.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ $github.event_name == "pull_request" ]]; then
+if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
 	echo "It's a PR"
 	
 	export SHOULD_BUILD="yes"


### PR DESCRIPTION
This PR is fixing a regression introduced in #666 which blocks the creation of any new release...
It's correctly determining when the run is a PR or not.
