### PR TITLE
rename data folder

### DIFF
--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -40,6 +40,7 @@ nameShort='setpath(["nameShort"]; "VSCodium")'
 nameLong='setpath(["nameLong"]; "VSCodium")'
 linuxIconName='setpath(["linuxIconName"]; "vscodium")'
 applicationName='setpath(["applicationName"]; "codium")'
+dataFolderName='setpath(["dataFolderName"]; ".vscodium")'
 win32MutexName='setpath(["win32MutexName"]; "vscodium")'
 win32DirName='setpath(["win32DirName"]; "VSCodium")'
 win32NameVersion='setpath(["win32NameVersion"]; "VSCodium")'
@@ -47,11 +48,12 @@ win32RegValueName='setpath(["win32RegValueName"]; "VSCodium")'
 win32AppUserModelId='setpath(["win32AppUserModelId"]; "Microsoft.VSCodium")'
 win32ShellNameShort='setpath(["win32ShellNameShort"]; "VSCodium")'
 win32x64UserAppId='setpath (["win32x64UserAppId"]; "{{2E1F05D1-C245-4562-81EE-28188DB6FD17}")'
+darwinBundleIdentifier='setpath(["darwinBundleIdentifier"]; "com.vscodium")'
 urlProtocol='setpath(["urlProtocol"]; "vscodium")'
 extensionAllowedProposedApi='setpath(["extensionAllowedProposedApi"]; getpath(["extensionAllowedProposedApi"]) + ["ms-vsliveshare.vsliveshare", "ms-vscode-remote.remote-ssh", "ms-vscode.cpptools", "ms-azuretools.vscode-docker", "visualstudioexptteam.vscodeintellicode", "ms-python.python"])'
-serverDataFolderName='setpath(["serverDataFolderName"]; ".vscode-server-oss")'
+serverDataFolderName='setpath(["serverDataFolderName"]; ".vscodium-server")'
 
-product_json_changes="${checksumFailMoreInfoUrl} | ${tipsAndTricksUrl} | ${twitterUrl} | ${requestFeatureUrl} | ${documentationUrl} | ${introductoryVideosUrl} | ${extensionAllowedBadgeProviders} | ${updateUrl} | ${releaseNotesUrl} | ${keyboardShortcutsUrlMac} | ${keyboardShortcutsUrlLinux} | ${keyboardShortcutsUrlWin} | ${quality} | ${extensionsGallery} | ${linkProtectionTrustedDomains} | ${nameShort} | ${nameLong} | ${linuxIconName} | ${applicationName} | ${win32MutexName} | ${win32DirName} | ${win32NameVersion} | ${win32RegValueName} | ${win32AppUserModelId} | ${win32ShellNameShort} | ${win32x64UserAppId} | ${urlProtocol} | ${extensionAllowedProposedApi} | ${serverDataFolderName}"
+product_json_changes="${checksumFailMoreInfoUrl} | ${tipsAndTricksUrl} | ${twitterUrl} | ${requestFeatureUrl} | ${documentationUrl} | ${introductoryVideosUrl} | ${extensionAllowedBadgeProviders} | ${updateUrl} | ${releaseNotesUrl} | ${keyboardShortcutsUrlMac} | ${keyboardShortcutsUrlLinux} | ${keyboardShortcutsUrlWin} | ${quality} | ${extensionsGallery} | ${linkProtectionTrustedDomains} | ${nameShort} | ${nameLong} | ${linuxIconName} | ${applicationName} | ${dataFolderName} | ${win32MutexName} | ${win32DirName} | ${win32NameVersion} | ${win32RegValueName} | ${win32AppUserModelId} | ${win32ShellNameShort} | ${win32x64UserAppId} | ${darwinBundleIdentifier} | ${urlProtocol} | ${extensionAllowedProposedApi} | ${serverDataFolderName}"
 cat product.json.bak | jq "${product_json_changes}" > product.json
 cat product.json
 


### PR DESCRIPTION
This PR renames the data folder's name, the bundle identifier on macOS to remove the reference to vscode-oss.

Renaming the data folder is **breaking** the extensions since they are kept into the old data folder.
I'm not sure how to tackle that issue.