### PR TITLE
Fix patch for builds using ProductService

### DIFF
--- a/patches/fix-rpm-spec.patch
+++ b/patches/fix-rpm-spec.patch
@@ -1,13 +1,5 @@
 --- vscode/resources/linux/rpm/code.spec.template	2021-03-02 19:26:53.000000000 +0100
 +++ vscode/resources/linux/rpm/code.spec.template.new	2021-03-02 19:28:12.000000000 +0100
-@@ -1,6 +1,6 @@
- Name:     @@NAME@@
- Version:  @@VERSION@@
--Release:  @@RELEASE@@.el7
-+Release:  @@RELEASE@@.el8
- Summary:  Code editing. Redefined.
- Group:    Development/Tools
- Vendor:   Microsoft Corporation
 @@ -69,3 +69,5 @@
  /usr/share/pixmaps/@@ICON@@.png
  /usr/share/bash-completion/completions/@@NAME@@

--- a/patches/update-cache-path.patch
+++ b/patches/update-cache-path.patch
@@ -3,5 +3,5 @@
 @@ -56,3 +56,3 @@
  	@memoize
  	get cachePath(): Promise<string> {
--		const result = path.join(tmpdir(), `vscode-update-${product.target}-${process.arch}`);
-+		const result = path.join(tmpdir(), `vscodium-update-${product.target}-${process.arch}`);
+-		const result = path.join(tmpdir(), `vscode-update-${this.productService.target}-${process.arch}`);
++		const result = path.join(tmpdir(), `vscodium-update-${this.productService.target}-${process.arch}`);


### PR DESCRIPTION
Upstream changed the line using the productService, causing build breakage.

This should unblock releasing 1.55