### PR TITLE
Use `applicationName` for update cache path

### DIFF
--- a/patches/update-cache-path.patch
+++ b/patches/update-cache-path.patch
@@ -7,7 +7,7 @@ index 93424ca..133657e 100644
  	@memoize
  	get cachePath(): Promise<string> {
 -		const result = path.join(tmpdir(), `vscode-update-${this.productService.target}-${process.arch}`);
-+		const result = path.join(tmpdir(), `${this.productService.nameShort.toLowerCase()}-update-${this.productService.target}-${process.arch}`);
++		const result = path.join(tmpdir(), `${this.productService.applicationName}-update-${this.productService.target}-${process.arch}`);
  		return pfs.Promises.mkdir(result, { recursive: true }).then(() => result);
  	}
  


### PR DESCRIPTION
Seems more appropriate, since `nameShort` is intended to be user-facing and could e.g. contain spaces.