### PR TITLE
Fix AppImage's dependency

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,10 +33,6 @@ jobs:
           image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
-      - name: Install desktop-file-utils
-        run: sudo apt-get install desktop-file-utils
-        if: matrix.vscode_arch == 'x64'
-  
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Install desktop-file-utils
         run: sudo apt-get install desktop-file-utils
-        if: env.VSCODE_ARCH == 'x64'
+        if: matrix.vscode_arch == 'x64'
   
       - uses: actions/checkout@v2
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,7 @@ jobs:
           image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
-      - name: Check existing VSCodium tags/releases
+      - name: Install desktop-file-utils
         run: sudo apt-get install desktop-file-utils
         if: env.VSCODE_ARCH == 'x64'
   

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,6 +33,10 @@ jobs:
           image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
+      - name: Check existing VSCodium tags/releases
+        run: sudo apt-get install desktop-file-utils
+        if: env.VSCODE_ARCH == 'x64'
+  
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment

--- a/create_appimage.sh
+++ b/create_appimage.sh
@@ -3,9 +3,6 @@
 cd ..
 
 if [[ "$VSCODE_ARCH" == "x64" ]]; then
-  # install a dep needed for this process
-  sudo apt-get install desktop-file-utils
-
   wget -c https://github.com/$(wget -q https://github.com/AppImage/pkg2appimage/releases -O - | grep "pkg2appimage-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
   chmod +x ./pkg2appimage-*.AppImage
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -53,7 +53,7 @@ docker run -ti --volume=<local vscodium source>:/root/vscodium --name=vscodium-b
 When inside the container, you can use the following commands to build:
 ```
 curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-sudo apt-get install -y nodejs
+sudo apt-get install -y nodejs desktop-file-utils
 
 npm install -g yarn
 


### PR DESCRIPTION
This PR is moving the dependency installation into workflow so non-Debian-based Linux can build the AppImage without the need to edit the bash script.