### PR TITLE
do not start crashReporter when appCenter isn't configured

### DIFF
--- a/patches/crash-reporter.patch
+++ b/patches/crash-reporter.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main.js b/src/main.js
+index 19dde20..d9611f2 100644
+--- a/src/main.js
++++ b/src/main.js
+@@ -409,6 +409,8 @@ function configureCrashReporter() {
+ 					argv.splice(endOfArgsMarkerIndex, 0, '--crash-reporter-id', crashReporterId);
+ 				}
+ 			}
++		} else {
++			return;
+ 		}
+ 	}
+ 


### PR DESCRIPTION
The PR is fixing the change between [Electron 13](https://github.com/electron/electron/blob/v13.1.7/docs/api/crash-reporter.md) and [Electron 12](https://github.com/electron/electron/blob/v12.0.13/docs/api/crash-reporter.md) where `submitURL` becomes a requirement.
This is a last minute change found on the `1.59`, I'm pushing the merge before the build process.