### PR TITLE
fix: fail build when a patch can't be applied

### DIFF
--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -11,7 +11,8 @@ cd vscode || exit
 for file in ../patches/*.patch; do
   if [ -f "$file" ]; then
     echo applying patch: $file;
-    if ! git apply --ignore-whitespace $file; then
+    git apply --ignore-whitespace "$file"
+    if [ $? -ne 0 ]; then
       echo failed to apply patch $file 1>&2
     fi
   fi
@@ -20,7 +21,8 @@ done
 for file in ../patches/user/*.patch; do
   if [ -f "$file" ]; then
     echo applying user patch: $file;
-    if ! git apply --ignore-whitespace $file; then
+    git apply --ignore-whitespace "$file"
+    if [ $? -ne 0 ]; then
       echo failed to apply patch $file 1>&2
     fi
   fi


### PR DESCRIPTION
This PR is fixing the test so the build fails when a patch can't be applied.