### PR TITLE
build: specify vscode version to build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Zip release
         run: |
           cd VSCode-linux-${VSCODE_ARCH}
-          tar czf ../VSCodium-linux-${VSCODE_ARCH}-${LATEST_MS_TAG}.tar.gz .
+          tar czf ../VSCodium-linux-${VSCODE_ARCH}-${MS_TAG}.tar.gz .
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
 
       - name: Generate shasums
@@ -94,7 +94,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
         with:
-          tag_name: ${{ env.LATEST_MS_TAG }}
+          tag_name: ${{ env.MS_TAG }}
           files: |
             ./*.sha256
             ./*.zip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,14 +84,14 @@ jobs:
       - name: Zip release
         run: |
           cd "VSCode-darwin-${VSCODE_ARCH}"
-          zip -r -X -y ../VSCodium-darwin-${VSCODE_ARCH}-${LATEST_MS_TAG}.zip ./*.app
+          zip -r -X -y ../VSCodium-darwin-${VSCODE_ARCH}-${MS_TAG}.zip ./*.app
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
 
       - name: DMG the release
         run: |
           pushd "VSCode-darwin-${VSCODE_ARCH}"
           npx create-dmg VSCodium.app ..
-          mv "../VSCodium ${LATEST_MS_TAG}.dmg" "../VSCodium.${VSCODE_ARCH}.${LATEST_MS_TAG}.dmg"
+          mv "../VSCodium ${MS_TAG}.dmg" "../VSCodium.${VSCODE_ARCH}.${MS_TAG}.dmg"
           popd
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
 
@@ -103,7 +103,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
         with:
-          tag_name: ${{ env.LATEST_MS_TAG }}
+          tag_name: ${{ env.MS_TAG }}
           files: |
             ./*.zip
             ./*.dmg

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,9 +79,9 @@ jobs:
 
       - name: Move/rename build artifacts
         run: |
-          mv vscode\\.build\\win32-${VSCODE_ARCH}\\system-setup\\VSCodeSetup.exe VSCodiumSetup-${VSCODE_ARCH}-${LATEST_MS_TAG}.exe
-          mv vscode\\.build\\win32-${VSCODE_ARCH}\\user-setup\\VSCodeSetup.exe VSCodiumUserSetup-${VSCODE_ARCH}-${LATEST_MS_TAG}.exe
-          mv vscode\\.build\\win32-${VSCODE_ARCH}\\archive\\VSCode-win32-${VSCODE_ARCH}.zip VSCodium-win32-${VSCODE_ARCH}-${LATEST_MS_TAG}.zip
+          mv vscode\\.build\\win32-${VSCODE_ARCH}\\system-setup\\VSCodeSetup.exe VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe
+          mv vscode\\.build\\win32-${VSCODE_ARCH}\\user-setup\\VSCodeSetup.exe VSCodiumUserSetup-${VSCODE_ARCH}-${MS_TAG}.exe
+          mv vscode\\.build\\win32-${VSCODE_ARCH}\\archive\\VSCode-win32-${VSCODE_ARCH}.zip VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip
         shell: bash
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
 
@@ -94,7 +94,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: env.SHOULD_BUILD == 'yes' && env.SHOULD_DEPLOY == 'yes'
         with:
-          tag_name: ${{ env.LATEST_MS_TAG }}
+          tag_name: ${{ env.MS_TAG }}
           files: |
             ./*.sha256
             ./VSCodium*.zip

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -ex
 if [[ "$SHOULD_BUILD" == "yes" ]]; then
   npm config set scripts-prepend-node-path true
 
-  echo "LATEST_MS_COMMIT: ${LATEST_MS_COMMIT}"
+  echo "MS_COMMIT: ${MS_COMMIT}"
 
   . prepare_vscode.sh
 

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -3,23 +3,23 @@
 set -e
 
 REPOSITORY=${GITHUB_REPOSITORY:-"VSCodium/vscodium"}
-GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$REPOSITORY/releases/tags/$LATEST_MS_TAG)
+GITHUB_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$REPOSITORY/releases/tags/$MS_TAG)
 VSCODIUM_ASSETS=$(echo $GITHUB_RESPONSE | jq '.assets')
 
 # if we just don't have the github token, get out fast
 if [ "$GITHUB_TOKEN" != "" ]; then
   if [ "$VSCODIUM_ASSETS" != "null" ]; then
     if [[ "$OS_NAME" == "osx" ]]; then
-      HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq --arg suffix "darwin-$VSCODE_ARCH-$LATEST_MS_TAG.zip" 'map(.name) | contains([$suffix])')
+      HAVE_MAC=$(echo $VSCODIUM_ASSETS | jq --arg suffix "darwin-$VSCODE_ARCH-$MS_TAG.zip" 'map(.name) | contains([$suffix])')
       if [[ "$HAVE_MAC" != "true" ]]; then
         echo "Building on Mac because we have no ZIP"
         export SHOULD_BUILD="yes"
       fi
     elif [[ "$OS_NAME" == "windows" ]]; then
       if [[ $VSCODE_ARCH == "arm64" ]]; then
-        HAVE_ARM64_SYS=$(echo $VSCODIUM_ASSETS | jq --arg suffix "VSCodiumSetup-$VSCODE_ARCH-$LATEST_MS_TAG.exe" 'map(.name) | contains([$suffix])')
-        HAVE_ARM64_USR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "UserSetup-$VSCODE_ARCH-$LATEST_MS_TAG.exe" 'map(.name) | contains([$suffix])')
-        HAVE_ARM64_ZIP=$(echo $VSCODIUM_ASSETS | jq --arg suffix "win32-$VSCODE_ARCH-$LATEST_MS_TAG.zip" 'map(.name) | contains([$suffix])')
+        HAVE_ARM64_SYS=$(echo $VSCODIUM_ASSETS | jq --arg suffix "VSCodiumSetup-$VSCODE_ARCH-$MS_TAG.exe" 'map(.name) | contains([$suffix])')
+        HAVE_ARM64_USR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "UserSetup-$VSCODE_ARCH-$MS_TAG.exe" 'map(.name) | contains([$suffix])')
+        HAVE_ARM64_ZIP=$(echo $VSCODIUM_ASSETS | jq --arg suffix "win32-$VSCODE_ARCH-$MS_TAG.zip" 'map(.name) | contains([$suffix])')
         if [[ "$HAVE_ARM64_SYS" != "true" ]]; then
           echo "Building on Windows arm64 because we have no system setup"
           export SHOULD_BUILD="yes"
@@ -36,9 +36,9 @@ if [ "$GITHUB_TOKEN" != "" ]; then
           echo "Already have all the Windows arm64 builds"
         fi
       elif [[ $VSCODE_ARCH == "ia32" ]]; then
-        HAVE_IA32_SYS=$(echo $VSCODIUM_ASSETS | jq --arg suffix "VSCodiumSetup-$VSCODE_ARCH-$LATEST_MS_TAG.exe" 'map(.name) | contains([$suffix])')
-        HAVE_IA32_USR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "UserSetup-$VSCODE_ARCH-$LATEST_MS_TAG.exe" 'map(.name) | contains([$suffix])')
-        HAVE_IA32_ZIP=$(echo $VSCODIUM_ASSETS | jq --arg suffix "win32-$VSCODE_ARCH-$LATEST_MS_TAG.zip" 'map(.name) | contains([$suffix])')
+        HAVE_IA32_SYS=$(echo $VSCODIUM_ASSETS | jq --arg suffix "VSCodiumSetup-$VSCODE_ARCH-$MS_TAG.exe" 'map(.name) | contains([$suffix])')
+        HAVE_IA32_USR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "UserSetup-$VSCODE_ARCH-$MS_TAG.exe" 'map(.name) | contains([$suffix])')
+        HAVE_IA32_ZIP=$(echo $VSCODIUM_ASSETS | jq --arg suffix "win32-$VSCODE_ARCH-$MS_TAG.zip" 'map(.name) | contains([$suffix])')
         if [[ "$HAVE_IA32_SYS" != "true" ]]; then
           echo "Building on Windows ia32 because we have no system setup"
           export SHOULD_BUILD="yes"
@@ -55,9 +55,9 @@ if [ "$GITHUB_TOKEN" != "" ]; then
           echo "Already have all the Windows ia32 builds"
         fi
       else # Windows x64
-        HAVE_X64_SYS=$(echo $VSCODIUM_ASSETS | jq --arg suffix "VSCodiumSetup-$VSCODE_ARCH-$LATEST_MS_TAG.exe" 'map(.name) | contains([$suffix])')
-        HAVE_X64_USR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "UserSetup-$VSCODE_ARCH-$LATEST_MS_TAG.exe" 'map(.name) | contains([$suffix])')
-        HAVE_X64_ZIP=$(echo $VSCODIUM_ASSETS | jq --arg suffix "win32-$VSCODE_ARCH-$LATEST_MS_TAG.zip" 'map(.name) | contains([$suffix])')
+        HAVE_X64_SYS=$(echo $VSCODIUM_ASSETS | jq --arg suffix "VSCodiumSetup-$VSCODE_ARCH-$MS_TAG.exe" 'map(.name) | contains([$suffix])')
+        HAVE_X64_USR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "UserSetup-$VSCODE_ARCH-$MS_TAG.exe" 'map(.name) | contains([$suffix])')
+        HAVE_X64_ZIP=$(echo $VSCODIUM_ASSETS | jq --arg suffix "win32-$VSCODE_ARCH-$MS_TAG.zip" 'map(.name) | contains([$suffix])')
         if [[ "$HAVE_X64_SYS" != "true" ]]; then
           echo "Building on Windows x64 because we have no system setup"
           export SHOULD_BUILD="yes"
@@ -77,7 +77,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
     elif [[ "$OS_NAME" == "linux" ]]; then
       if [[ $VSCODE_ARCH == "arm64" ]]; then
         HAVE_ARM64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["arm64.deb"])')
-        HAVE_ARM64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+        HAVE_ARM64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "arm64-$MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
         if [[ "$HAVE_ARM64_DEB" != "true" ]]; then
           echo "Building on Linux arm64 because we have no DEB"
           export SHOULD_BUILD="yes"
@@ -91,7 +91,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
         fi
       elif [[ $VSCODE_ARCH == "armhf" ]]; then
         HAVE_ARM_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["armhf.deb"])')
-        HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "armhf-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+        HAVE_ARM_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "armhf-$MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
         if [[ "$HAVE_ARM_DEB" != "true" ]]; then
           echo "Building on Linux arm because we have no DEB"
           export SHOULD_BUILD="yes"
@@ -106,7 +106,7 @@ if [ "$GITHUB_TOKEN" != "" ]; then
       else # Linux x64
         HAVE_64_RPM=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["x86_64.rpm"])')
         HAVE_64_DEB=$(echo $VSCODIUM_ASSETS | jq 'map(.name) | contains(["amd64.deb"])')
-        HAVE_64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "x64-$LATEST_MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
+        HAVE_64_TAR=$(echo $VSCODIUM_ASSETS | jq --arg suffix "x64-$MS_TAG.tar.gz" 'map(.name) | contains([$suffix])')
         if [[ "$HAVE_64_RPM" != "true" ]]; then
           echo "Building on Linux x64 because we have no RPM"
           export SHOULD_BUILD="yes"

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -1,26 +1,40 @@
 #!/bin/bash
 
+mkdir -p vscode
+cd vscode
+
+git init -q
+git remote add origin https://github.com/Microsoft/vscode.git
+
 # figure out latest tag by calling MS update API
 if [ "$INSIDER" == "1" ]; then
 	UPDATE_INFO=$(curl https://update.code.visualstudio.com/api/update/darwin/insider/lol)
-else
+    export MS_COMMIT=$(echo $UPDATE_INFO | jq -r '.version')
+    export MS_TAG=$(echo $UPDATE_INFO | jq -r '.name')
+elif [[ -z "${MS_TAG}" ]]; then
 	UPDATE_INFO=$(curl https://update.code.visualstudio.com/api/update/darwin/stable/lol)
-fi
-export LATEST_MS_COMMIT=$(echo $UPDATE_INFO | jq -r '.version')
-export LATEST_MS_TAG=$(echo $UPDATE_INFO | jq -r '.name')
-echo "Got the latest MS tag: ${LATEST_MS_TAG} version: ${LATEST_MS_COMMIT}"
-
-if [ "$INSIDER" == "1" ]; then
-	mkdir -p vscode; cd vscode
-	git init ; git remote add origin https://github.com/Microsoft/vscode.git
-	git fetch --depth 1 origin $LATEST_MS_COMMIT; git checkout FETCH_HEAD
-	cd ..
+    export MS_COMMIT=$(echo $UPDATE_INFO | jq -r '.version')
+    export MS_TAG=$(echo $UPDATE_INFO | jq -r '.name')
 else
-	git clone https://github.com/Microsoft/vscode.git --branch $LATEST_MS_TAG --depth 1
+    tag_line=$( git ls-remote --tags --sort=-version:refname | grep "refs\/tags\/${MS_TAG}" | head -1 )
+
+    [[ "${tag_line}" =~ ^([[:alnum:]]+)[[:space:]]+refs\/tags\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+
+    export MS_COMMIT="${BASH_REMATCH[1]}"
 fi
+
+echo "Got the MS tag: ${MS_TAG} version: ${MS_COMMIT}"
+
+git fetch --depth 1 origin $MS_COMMIT
+git checkout FETCH_HEAD
+
+cd ..
 
 # for GH actions
 if [[ $GITHUB_ENV ]]; then
-	echo "LATEST_MS_COMMIT=$LATEST_MS_COMMIT" >> $GITHUB_ENV
-	echo "LATEST_MS_TAG=$LATEST_MS_TAG" >> $GITHUB_ENV
+	if [[ -z "${MS_TAG}" ]]; then
+		echo "MS_TAG=$MS_TAG" >> $GITHUB_ENV
+	fi
+	
+	echo "MS_COMMIT=$MS_COMMIT" >> $GITHUB_ENV
 fi

--- a/update_version.sh
+++ b/update_version.sh
@@ -16,15 +16,15 @@ fi
 #  }
 
 # `url` is URL_BASE + filename of asset e.g.
-#    darwin: https://github.com/VSCodium/vscodium/releases/download/${LATEST_MS_TAG}/VSCodium-darwin-${LATEST_MS_TAG}.zip
-# `name` is $LATEST_MS_TAG
-# `version` is $LATEST_MS_COMMIT
-# `productVersion` is $LATEST_MS_TAG
+#    darwin: https://github.com/VSCodium/vscodium/releases/download/${MS_TAG}/VSCodium-darwin-${MS_TAG}.zip
+# `name` is $MS_TAG
+# `version` is $MS_COMMIT
+# `productVersion` is $MS_TAG
 # `hash` in <filename>.sha1
 # `timestamp` is $(node -e 'console.log(Date.now())')
 # `sha256hash` in <filename>.sha256
 
-URL_BASE=https://github.com/VSCodium/vscodium/releases/download/${LATEST_MS_TAG}
+URL_BASE=https://github.com/VSCodium/vscodium/releases/download/${MS_TAG}
 
 # to make testing on forks easier
 VERSIONS_REPO="${GITHUB_USERNAME}/versions"
@@ -37,9 +37,9 @@ generateJson() {
 
   # generate parts
   local url=${URL_BASE}/${assetName}
-  local name=$LATEST_MS_TAG
-  local version=$LATEST_MS_COMMIT
-  local productVersion=$LATEST_MS_TAG
+  local name=$MS_TAG
+  local version=$MS_COMMIT
+  local productVersion=$MS_TAG
   local timestamp=$(node -e 'console.log(Date.now())')
 
   local sha1hash=$(cat ${assetName}.sha1 | awk '{ print $1 }')
@@ -93,25 +93,25 @@ cd ..
 
 if [[ "$OS_NAME" == "osx" ]]; then
   # zip, sha1, and sha256 files are all at top level dir
-  ASSET_NAME=VSCodium-darwin-${VSCODE_ARCH}-${LATEST_MS_TAG}.zip
+  ASSET_NAME=VSCodium-darwin-${VSCODE_ARCH}-${MS_TAG}.zip
   VERSION_PATH="darwin/${VSCODE_ARCH}"
   JSON="$(generateJson ${ASSET_NAME})"
   updateLatestVersion "$VERSION_PATH" "$JSON"
 elif [[ "$OS_NAME" == "windows" ]]; then
   # system installer
-  ASSET_NAME=VSCodiumSetup-${VSCODE_ARCH}-${LATEST_MS_TAG}.exe
+  ASSET_NAME=VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe
   VERSION_PATH="win32/${VSCODE_ARCH}/system"
   JSON="$(generateJson ${ASSET_NAME})"
   updateLatestVersion "$VERSION_PATH" "$JSON"
 
   # user installer
-  ASSET_NAME=VSCodiumUserSetup-${VSCODE_ARCH}-${LATEST_MS_TAG}.exe
+  ASSET_NAME=VSCodiumUserSetup-${VSCODE_ARCH}-${MS_TAG}.exe
   VERSION_PATH="win32/${VSCODE_ARCH}/user"
   JSON="$(generateJson ${ASSET_NAME})"
   updateLatestVersion "$VERSION_PATH" "$JSON"
 
   # windows archive
-  ASSET_NAME=VSCodium-win32-${VSCODE_ARCH}-${LATEST_MS_TAG}.zip
+  ASSET_NAME=VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip
   VERSION_PATH="win32/${VSCODE_ARCH}/archive"
   JSON="$(generateJson ${ASSET_NAME})"
   updateLatestVersion "$VERSION_PATH" "$JSON"
@@ -119,7 +119,7 @@ else # linux
   # update service links to tar.gz file
   # see https://update.code.visualstudio.com/api/update/linux-x64/stable/VERSION
   # as examples
-  ASSET_NAME=VSCodium-linux-${VSCODE_ARCH}-${LATEST_MS_TAG}.tar.gz
+  ASSET_NAME=VSCodium-linux-${VSCODE_ARCH}-${MS_TAG}.tar.gz
   VERSION_PATH="linux/${VSCODE_ARCH}"
   JSON="$(generateJson ${ASSET_NAME})"
   updateLatestVersion "$VERSION_PATH" "$JSON"


### PR DESCRIPTION
This PR allows to specify which VSCode version to use with the environment variable `MS_TAG`