### PR TITLE
fix: don't loop when there is no assets in the tag

### DIFF
--- a/check_tags.sh
+++ b/check_tags.sh
@@ -4,7 +4,7 @@ set -e
 
 REPOSITORY="${GITHUB_REPOSITORY:-"VSCodium/vscodium"}"
 GITHUB_RESPONSE=$( curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$REPOSITORY/releases/tags/$MS_TAG)
-VSCODIUM_ASSETS=$( echo $GITHUB_RESPONSE | jq -c '.assets | map(.name)' )
+VSCODIUM_ASSETS=$( echo $GITHUB_RESPONSE | jq -c '.assets | map(.name)?' )
 
 contains() {
   # add " to match the end of a string so any hashs won't be matched by mistake


### PR DESCRIPTION
This PR is fixing the error `Cannot iterate over null` due to no assets in the tag or the tag doesn't exist.