### PR TITLE
fix: remove macos arm64 build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,8 +18,8 @@ jobs:
         include:
           - vscode_arch: x64
             os: macOS-10.15
-          - vscode_arch: arm64
-            os: macOS-11
+          # - vscode_arch: arm64
+          #   os: macOS-11
 
     env:
       OS_NAME: "osx"


### PR DESCRIPTION
This PR is removing the macOS arm64 build until something else can do it since I'm not able to test it.