### PR TITLE
update build.md

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -25,6 +25,9 @@
 - rpm
 - rpmbuild
 - dpkg
+- python (can't be just python3, can't be user alias)
+- libsecret-1-dev
+- imagemagick
 
 ### <a id="dependencies-macos"></a>MacOS
 


### PR DESCRIPTION
update dependencies list

- python 
  - I have Ubuntu and Python is available at start only using `python3`. I had an alias `alias python=python3` but the build script throws an error `/bin/sh: 1: python: not found` . I created a symlink `sudo ln -s /usr/bin/python3 /usr/bin/python` but one can also do `apt install python-is-python3`. After the symlink there is no error.
- libsecret-1-dev
  - without this package I was getting this error `Error: Could not detect abi for version 13.5.1 and runtime electron`
- imagemagick
  - without this package I was getting this error `/tmp/recipe_script: line 4: /usr/bin/convert: No such file or directory`