### PR TITLE
remove MacOS depencencies part in build guide

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -4,7 +4,6 @@
 
 - [Dependencies](#dependencies)
   - [Linux](#dependencies-linux)
-  - [MacOS](#dependencies-macos)
   - [Windows](#dependencies-windows)
 - [Build Scripts](#build-scripts)
 - [Build in Docker](#build-docker)
@@ -31,8 +30,6 @@
 - python3
 - libsecret-1-dev
 - imagemagick (for AppImage)
-
-### <a id="dependencies-macos"></a>MacOS
 
 ### <a id="dependencies-windows"></a>Windows
 


### PR DESCRIPTION
for some reason macos is included in the build guide but with no dependencies? so i removed it