### PR TITLE
ci: disable snap for arm64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         platform:
         - amd64
-        - arm64
+        # - arm64
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The PR is fixing a mistake so the snap isn't tried to be built for arm64 in favor of a release for x64.