### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,13 +32,13 @@ jobs:
           image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install GH
         run: ./install_gh.sh
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14
 
@@ -68,7 +68,7 @@ jobs:
         if: env.SHOULD_BUILD == 'yes'
 
       - name: Cache yarn directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarnCacheDirPath.outputs.dir }}
           key: linux-${{ matrix.npm_arch }}-yarnCacheDir-${{ steps.yarnCacheKey.outputs.value }}
@@ -110,7 +110,7 @@ jobs:
         # - arm64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check version
         run: ./stores/snapcraft/check_version.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,10 +26,10 @@ jobs:
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14
 
@@ -56,7 +56,7 @@ jobs:
         if: env.SHOULD_BUILD == 'yes'
 
       - name: Cache yarn directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarnCacheDirPath.outputs.dir }}
           key: ${{ env.OS_NAME }}-${{ env.VSCODE_ARCH }}-yarnCacheDir-${{ steps.yarnCacheKey.outputs.value }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,10 +23,10 @@ jobs:
         vscode_arch: [x64, ia32, arm64]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14
 
@@ -34,7 +34,7 @@ jobs:
         run: npm install -g yarn
 
       - name: Setup Python 2
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '2.x'
 
@@ -61,7 +61,7 @@ jobs:
         if: env.SHOULD_BUILD == 'yes'
 
       - name: Cache yarn directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarnCacheDirPath.outputs.dir }}
           key: ${{ env.OS_NAME }}-${{ env.VSCODE_ARCH }}-yarnCacheDir-${{ steps.yarnCacheKey.outputs.value }}


### PR DESCRIPTION
Bump GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12, which is EOL at end of month.

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)
- Releases for `actions/cache` can be [found here](https://github.com/actions/cache/releases)
- Releases for `actions/setup-python` can be [found here](https://github.com/actions/setup-python/releases)