### PR TITLE
Update urls

### DIFF
--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -1,6 +1,6 @@
-# dc.services.visualstudio.com
+# mobile.events.data.microsoft.com
 # vortex.data.microsoft.com
-TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
+TELEMETRY_URLS="[^/]+\.data\.microsoft\.com"
 REPLACEMENT="s/$TELEMETRY_URLS/0\.0\.0\.0/g"
 
 #include common functions


### PR DESCRIPTION
Vortex [is being phased out](https://github.com/microsoft/vscode/commit/dcc5c9c0fb4aa4bd43312afe871e2388801da409#diff-3ebafa0a47a7b5296b77794315a8b55d0ed679f429b6992f4f8f8fd8a2052c83L32), but still [exists in some of the dependencies](https://github.com/microsoft/vscode-extension-telemetry/blob/e412a10980ad10d2c70c72b6bdb621fe25a2f2c0/src/node/telemetryReporter.ts#L52), so it would be wise to keep it. I couldn't find any references to dc.services.visualstudio.com, which is also absent from [docs](https://code.visualstudio.com/docs/setup/network#_common-hostnames), so I thought that'd be a candidate for a replace.