### PR TITLE
fix: re-enable 32bits builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,9 +27,9 @@ jobs:
         - vscode_arch: arm64
           npm_arch: arm64
           image: vscodium/vscodium-linux-build-agent:stretch-arm64
-        # - vscode_arch: armhf
-        #   npm_arch: armv7l
-        #   image: vscodium/vscodium-linux-build-agent:stretch-armhf
+        - vscode_arch: armhf
+          npm_arch: armv7l
+          image: vscodium/vscodium-linux-build-agent:stretch-armhf
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         vscode_arch:
           - x64
-          # - ia32
+          - ia32
           - arm64
 
     steps:

--- a/docs/build.md
+++ b/docs/build.md
@@ -55,6 +55,8 @@ Each platform has its build helper script in the directory `build`.
 
 To build for Linux, you can alternatively build VSCodium in docker
 
+### X64
+
 Firstly, create the container with:
 ```
 docker run -ti --volume=<local vscodium source>:/root/vscodium --name=vscodium-build-agent vscodium/vscodium-linux-build-agent:bionic-x64 bash
@@ -67,15 +69,38 @@ sudo apt-get install -y nodejs desktop-file-utils
 
 npm install -g yarn
 
-git clone https://github.com/VSCodium/vscodium.git
-
-cd vscodium
+cd /root/vscodium
 
 ./get_repo.sh
 
 export SHOULD_BUILD=yes
 export OS_NAME=linux
 export VSCODE_ARCH=x64
+
+./build.sh
+```
+
+### ARM 32bits
+
+Firstly, create the container with:
+```
+docker run -ti --volume=<local vscodium source>:/root/vscodium --name=vscodium-build-agent vscodium/vscodium-linux-build-agent:stretch-armhf bash
+```
+
+When inside the container, you can use the following commands to build:
+```
+curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo apt-get install -y nodejs desktop-file-utils
+
+cd /root/vscodium
+
+./get_repo.sh
+
+export SHOULD_BUILD=yes
+export OS_NAME=linux
+export VSCODE_ARCH=armhf
+export npm_config_arch=armv7l
+export npm_config_force_process_config="true"
 
 ./build.sh
 ```

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -34,9 +34,19 @@ done
 
 set -x
 
-if [[ "$OS_NAME" == "osx" ]]; then
+if [[ "${OS_NAME}" == "osx" ]]; then
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile --ignore-optional
   npm_config_argv='{"original":["--ignore-optional"]}' yarn postinstall
+elif [[ "${npm_config_arch}" == "armv7l" || "${npm_config_arch}" == "ia32" ]]; then
+  # node-gyp@9.0.0 shipped with node@16.15.0 starts using config.gypi
+  # from the custom headers path if dist-url option was set instead of
+  # using the config value from the process. Electron builds with pointer compression
+  # enabled for x64 and arm64, but incorrectly ships a single copy of config.gypi
+  # with v8_enable_pointer_compression option always set for all target architectures.
+  # We use the force_process_config option to use the config.gypi from the
+  # nodejs process executing npm for 32-bit architectures.
+  export npm_config_force_process_config="true"
+  CHILD_CONCURRENCY=1 yarn --frozen-lockfile
 else
   CHILD_CONCURRENCY=1 yarn --frozen-lockfile
 fi


### PR DESCRIPTION
The PR is re-enabling the 32bits builds with solution found by @theofficialgman in https://github.com/VSCodium/vscodium/issues/1072#issuecomment-1126740383_