### PR TITLE
vcs: add workflow to lock old closed issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,14 @@
+name: Lock Threads
+
+on:
+  schedule:
+    - cron: '0 0 * * Mon'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '90'


### PR DESCRIPTION
This PR is adding a workflow which locks the closed issues older than 90 days.