### PR TITLE
build: Use `cd ... || exit` in case `cd` fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ if [[ "${SHOULD_BUILD}" == "yes" ]]; then
 
   . prepare_vscode.sh
 
-  cd vscode || exit
+  cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
   yarn monaco-compile-check
   yarn valid-layers-check

--- a/build/windows/rtf/make.sh
+++ b/build/windows/rtf/make.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"/../../../vscode || exit
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../../../vscode || { echo "'vscode' dir not found"; exit 1; }
 
 input=LICENSE.txt
 target=LICENSE.rtf

--- a/build/windows/rtf/make.sh
+++ b/build/windows/rtf/make.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"/../../../vscode
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../../../vscode || exit
 
 input=LICENSE.txt
 target=LICENSE.rtf

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p vscode
-cd vscode || exit
+cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
 git init -q
 git remote add origin https://github.com/Microsoft/vscode.git

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mkdir -p vscode
-cd vscode
+cd vscode || exit
 
 git init -q
 git remote add origin https://github.com/Microsoft/vscode.git

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -5,7 +5,7 @@ set -e
 cp -rp src/* vscode/
 cp -f LICENSE vscode/LICENSE.txt
 
-cd vscode || exit
+cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
 ../update_settings.sh
 


### PR DESCRIPTION
Already being done here:

https://github.com/VSCodium/vscodium/blob/98d30bdc2c373068f1409cad1e98709b8c9e6afe/build.sh#L13