### PR TITLE
build(stores/snapcraft): quote grep pattern so shell won't interpret it

### DIFF
--- a/stores/snapcraft/check_version.sh
+++ b/stores/snapcraft/check_version.sh
@@ -19,7 +19,7 @@ else
 
   echo "Architecture: ${ARCHITECTURE}"
 
-  SNAP_VERSION=$(snapcraft list-revisions codium | grep -F stable* | grep "${ARCHITECTURE}" | tr -s ' ' | cut -d ' ' -f 4)
+  SNAP_VERSION=$(snapcraft list-revisions codium | grep -F "stable*" | grep "${ARCHITECTURE}" | tr -s ' ' | cut -d ' ' -f 4)
   echo "Snap version: ${SNAP_VERSION}"
 
   wget --quiet https://api.github.com/repos/VSCodium/vscodium/releases -O gh_latest.json


### PR DESCRIPTION
Regex passed to grep frequently contains characters that collide with globs, quoting it stops that from happening.