### PR TITLE
fix: use env variable instead of `login` option

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,7 +116,7 @@ jobs:
         run: ./stores/snapcraft/check_version.sh
         env:
           ARCHITECTURE: ${{ matrix.platform }}
-          SNAP_STORE_LOGIN: ${{ secrets.SNAP_STORE_LOGIN }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
 
       # - uses: docker/setup-qemu-action@v1
       #   if: env.SHOULD_DEPLOY == 'yes'
@@ -142,7 +142,8 @@ jobs:
 
       - uses: snapcore/action-publish@v1
         with:
-          store_login: ${{ secrets.SNAP_STORE_LOGIN }}
           snap: ${{ steps.build.outputs.snap }}
           release: stable
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         if: env.SHOULD_DEPLOY == 'yes'

--- a/stores/snapcraft/check_version.sh
+++ b/stores/snapcraft/check_version.sh
@@ -15,8 +15,6 @@ else
 
   sudo snap install --channel stable --classic snapcraft
 
-  echo "${SNAP_STORE_LOGIN}" | snapcraft login --with -
-
   echo "Architecture: ${ARCHITECTURE}"
 
   SNAP_VERSION=$(snapcraft list-revisions codium | grep -F "stable*" | grep "${ARCHITECTURE}" | tr -s ' ' | cut -d ' ' -f 4)


### PR DESCRIPTION
This PR uses the  environment variable `SNAPCRAFT_STORE_CREDENTIALS` since we are getting the following error:
```
/snap/bin/snapcraft login --with /tmp/login-data-UK8Fip/login.txt
--with is no longer supported, export the auth to the environment variable 'SNAPCRAFT_STORE_CREDENTIALS' instead     
```