### PR TITLE
patch: use github versions of included extensions

### DIFF
--- a/patches/use-github-extensions.patch
+++ b/patches/use-github-extensions.patch
@@ -1,0 +1,12 @@
+diff --git a/build/gulpfile.extensions.js b/build/gulpfile.extensions.js
+--- a/build/gulpfile.extensions.js
++++ b/build/gulpfile.extensions.js
+@@ -223,7 +223,7 @@ const cleanExtensionsBuildTask = task.define('clean-extensions-build', util.rimr
+ const compileExtensionsBuildTask = task.define('compile-extensions-build', task.series(
+ 	cleanExtensionsBuildTask,
+ 	task.define('bundle-extensions-build', () => ext.packageLocalExtensionsStream(false).pipe(gulp.dest('.build'))),
+-	task.define('bundle-marketplace-extensions-build', () => ext.packageMarketplaceExtensionsStream(false, product.extensionsGallery?.serviceUrl).pipe(gulp.dest('.build'))),
++	task.define('bundle-marketplace-extensions-build', () => ext.packageMarketplaceExtensionsStream(false).pipe(gulp.dest('.build'))),
+ ));
+ 
+ gulp.task(compileExtensionsBuildTask);


### PR DESCRIPTION
This disables the use of the marketplace to download the bundled extensions and uses GitHub links instead.

@daiyam I played around with the patch set. It feels a little fragile because there is no version dependence between the VSCodium tree and the VSCode release (like a commit reference of similar). (Also, using the update [endpoint](https://update.code.visualstudio.com/api/update/) is a potential TOS violation...)

I wrote a little script to apply and/or regenerate the patch set using (GitPython). I can clean it up and post it somewhere, if there is interest.
```
[14:03:05] Downloading extension from GH: ms-vscode.js-debug-companion@1.0.18 ...
[14:03:05] Downloading extension from GH: ms-vscode.js-debug@1.68.0 ...
[14:03:05] Downloading extension from GH: ms-vscode.vscode-js-profile-table@1.0.2 ...
```

This should fix the extension part of [#1095](https://github.com/VSCodium/vscodium/pull/1095).
