### PR TITLE
feat: add script to update patches

### DIFF
--- a/build/update_patches.sh
+++ b/build/update_patches.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd vscode || { echo "'vscode' dir not found"; exit 1; }
+
+git add .
+git reset -q --hard HEAD
+
+for file in ../patches/*.patch; do
+  if [ -f "${file}" ]; then
+    echo applying patch: "${file}"
+    git apply --ignore-whitespace "${file}"
+    if [ $? -ne 0 ]; then
+      echo failed to apply patch "${file}"
+      git apply --reject "${file}"
+      read -p "Press any key when the conflict have been resolved..." -n1 -s
+      git diff > "${file}"
+    fi
+    git add .
+    git reset -q --hard HEAD
+  fi
+done

--- a/docs/build.md
+++ b/docs/build.md
@@ -8,7 +8,11 @@
   - [Windows](#dependencies-windows)
 - [Build Scripts](#build-scripts)
 - [Build in Docker](#build-docker)
+  - [X64](#build-docker-x64)
+  - [ARM 32bits](#build-docker-arm32)
 - [Patch Update Process](#patch-update-process)
+  - [Semi-Automated](#patch-update-process-semiauto)
+  - [Manual](#patch-update-process-manual)
 
 ## <a id="dependencies"></a>Dependencies
 
@@ -55,7 +59,7 @@ Each platform has its build helper script in the directory `build`.
 
 To build for Linux, you can alternatively build VSCodium in docker
 
-### X64
+### <a id="build-docker-x64"></a>X64
 
 Firstly, create the container with:
 ```
@@ -80,7 +84,7 @@ export VSCODE_ARCH=x64
 ./build.sh
 ```
 
-### ARM 32bits
+### <a id="build-docker-arm32"></a>ARM 32bits
 
 Firstly, create the container with:
 ```
@@ -107,8 +111,20 @@ export npm_config_force_process_config="true"
 
 ## <a id="patch-update-process"></a>Patch Update Process
 
+## <a id="patch-update-process-semiauto"></a>Semi-Automated
+
 - run `./build/build_<os>.sh`, if a patch is failing then,
-- open vscode directory in vscodium
+- run `./build/update_patches.sh`
+- when the script pause at `Press any key when the conflict have been resolved...`, open `vscode` directory in **VSCodium**
+- fix all the `*.rej` files
+- run `yarn watch`
+- run `./script/code.sh` until everything ok
+- press any key to continue the script `update_patches.sh`
+
+## <a id="patch-update-process-manual"></a>Manual
+
+- run `./build/build_<os>.sh`, if a patch is failing then,
+- open `vscode` directory in **VSCodium**
 - revert all changes
 - run `git apply --reject ../patches/<name>.patch`
 - fix all the `*.rej` files


### PR DESCRIPTION
This PR adds a simple script to update the patches more easily.

It loops over over the patches and when a patch fails then:
- it apply the patch and generates the `.rej` files
- pause the script until the user has resolved all the conflicts
- when a key has been pressed, it generates the `.patch` file