### PR TITLE
fix: update api proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vscode
 VS*/*
+VSCode*
 .DS_Store
 build/linux/appimage/out
 build/linux/appimage/pkg2appimage.AppDir

--- a/build/update_api.sh
+++ b/build/update_api.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+URL=`curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/stable/VERSION" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/'`
+# echo "url: ${URL}"
+FILE=`echo "${URL}" | sed -E 's|.*/([^/]+\.zip)$|\1|'`
+# echo "file: ${FILE}"
+DIRECTORY=`echo "${URL}" | sed -E 's|.*/([^/]+)\.zip$|\1|'`
+# echo "directory: ${DIRECTORY}"
+
+if [[ ! -f "${FILE}" ]]; then
+  wget "${URL}"
+fi
+
+if [[ ! -d "${DIRECTORY}" ]]; then
+  unzip "${FILE}" -d "${DIRECTORY}"
+fi
+
+APIS=`cat ${DIRECTORY}/resources/app/product.json | jq -r '.extensionEnabledApiProposals'`
+
+cat <<< $(jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json) > product.json

--- a/product.json
+++ b/product.json
@@ -51,7 +51,8 @@
       "testObserver"
     ],
     "VisualStudioExptTeam.vscodeintellicode-completions": [
-      "inlineCompletions"
+      "inlineCompletionsNew",
+      "inlineCompletionsAdditions"
     ],
     "ms-vsliveshare.vsliveshare": [
       "contribMenuBarHome",
@@ -61,13 +62,12 @@
       "findTextInFiles",
       "notebookCellExecutionState",
       "notebookContentProvider",
-      "notebookDocumentEvents",
       "notebookEditor",
       "notebookEditorEdit",
       "notebookLiveShare",
+      "notebookWorkspaceEdit",
       "terminalDimensions",
       "terminalDataWriteEvent",
-      "textDocumentNotebook",
       "textSearchProvider"
     ],
     "ms-vscode.js-debug": [
@@ -82,25 +82,20 @@
     ],
     "ms-python.python": [
       "quickPickSortByLabel",
-      "testObserver",
-      "notebookEditor"
+      "testObserver"
     ],
     "ms-dotnettools.dotnet-interactive-vscode": [
-      "notebookConcatTextDocument",
-      "notebookContentProvider",
       "notebookCellExecutionState",
       "notebookControllerKind",
       "notebookDebugOptions",
-      "notebookDeprecated",
       "notebookEditor",
-      "notebookEditorDecorationType",
-      "notebookEditorEdit",
       "notebookLiveShare",
       "notebookMessaging",
       "notebookMime",
-      "textDocumentNotebook"
+      "notebookWorkspaceEdit"
     ],
     "GitHub.codespaces": [
+      "contribEditSessions",
       "contribMenuBarHome",
       "contribRemoteHelp",
       "contribViewsRemote",
@@ -112,10 +107,10 @@
     "ms-vscode.azure-repos": [
       "extensionRuntime",
       "fileSearchProvider",
-      "resolvers",
       "textSearchProvider"
     ],
     "ms-vscode.remote-repositories": [
+      "contribEditSessions",
       "contribRemoteHelp",
       "contribMenuBarHome",
       "contribViewsRemote",
@@ -128,14 +123,7 @@
       "scmSelectedProvider",
       "scmValidation",
       "textSearchProvider",
-      "timeline",
-      "notebookEditor"
-    ],
-    "ms-vscode.vscode-github-issue-notebooks": [
-      "notebookEditor"
-    ],
-    "tanhakabir.rest-book": [
-      "notebookEditor"
+      "timeline"
     ],
     "ms-vscode-remote.remote-wsl": [
       "resolvers",
@@ -147,6 +135,10 @@
       "terminalDataWriteEvent",
       "contribViewsRemote",
       "telemetry"
+    ],
+    "ms-vscode.remote-server": [
+      "resolvers",
+      "contribViewsRemote"
     ],
     "ms-vscode-remote.remote-containers": [
       "resolvers",
@@ -164,15 +156,18 @@
       "documentFiltersExclusive"
     ],
     "GitHub.vscode-pull-request-github": [
-      "tokenInformation"
+      "tokenInformation",
+      "commentsResolvedState",
+      "badges",
+      "contribViewSize"
     ],
     "GitHub.copilot": [
-      "inlineCompletions",
-      "textDocumentNotebook"
+      "inlineCompletionsNew",
+      "inlineCompletionsAdditions"
     ],
     "GitHub.copilot-nightly": [
-      "inlineCompletions",
-      "textDocumentNotebook"
+      "inlineCompletionsNew",
+      "inlineCompletionsAdditions"
     ],
     "GitHub.remotehub": [
       "contribRemoteHelp",
@@ -184,12 +179,10 @@
       "fileSearchProvider",
       "quickPickSortByLabel",
       "workspaceTrust",
-      "resolvers",
       "scmSelectedProvider",
       "scmValidation",
       "textSearchProvider",
-      "timeline",
-      "notebookEditor"
+      "timeline"
     ],
     "GitHub.remotehub-insiders": [
       "contribRemoteHelp",
@@ -201,48 +194,47 @@
       "fileSearchProvider",
       "quickPickSortByLabel",
       "workspaceTrust",
-      "resolvers",
       "scmSelectedProvider",
       "scmValidation",
       "textSearchProvider",
-      "timeline",
-      "notebookEditor"
+      "timeline"
     ],
     "ms-python.gather": [
-      "notebookEditor",
       "notebookCellExecutionState"
     ],
     "ms-python.vscode-pylance": [
-      "notebookDocumentEvents",
       "notebookEditor",
       "notebookCellExecutionState"
     ],
     "ms-toolsai.jupyter": [
-      "notebookConcatTextDocument",
       "notebookControllerKind",
       "notebookDebugOptions",
       "notebookDeprecated",
-      "notebookEditor",
-      "notebookDocumentEvents",
-      "notebookEditorDecorationType",
-      "notebookEditorEdit",
+      "notebookWorkspaceEdit",
       "notebookMessaging",
       "notebookMime",
       "notebookCellExecutionState",
       "portsAttributes",
-      "textDocumentNotebook",
-      "quickPickSortByLabel"
+      "quickPickSortByLabel",
+      "notebookKernelSource",
+      "interactiveWindow"
+    ],
+    "ms-toolsai.vscode-jupyter-powertoys": [
+      "notebookWorkspaceEdit"
     ],
     "dbaeumer.vscode-eslint": [
-      "tabs",
-      "notebookDocumentEvents",
-      "notebookEditor",
       "notebookCellExecutionState"
     ],
     "ms-vscode.azure-sphere-tools-ui": [
       "resolvers"
     ],
     "ms-azuretools.vscode-azureappservice": [
+      "terminalDataWriteEvent"
+    ],
+    "ms-vscode.anycode": [
+      "extensionsAny"
+    ],
+    "ms-vscode.cpptools": [
       "terminalDataWriteEvent"
     ]
   },


### PR DESCRIPTION
This PR updates the `extensionEnabledApiProposals` property in the `product.json`

It also adds the script `build/update_api.sh` which update that property from VSCode.

Fixes #1184