### PR TITLE
feat: add release number

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Check existing VSCodium tags/releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_RELEASE: ${{ secrets.NEW_RELEASE }}
         run: ./check_tags.sh
         if: env.SHOULD_DEPLOY == 'yes'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Check existing VSCodium tags/releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_RELEASE: ${{ secrets.NEW_RELEASE }}
         run: . check_tags.sh
         if: env.SHOULD_DEPLOY == 'yes'
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Check existing VSCodium tags/releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_RELEASE: ${{ secrets.NEW_RELEASE }}
         run: ./check_tags.sh
         if: env.SHOULD_DEPLOY == 'yes'
 

--- a/build/windows/msi/build.sh
+++ b/build/windows/msi/build.sh
@@ -25,9 +25,9 @@ LICENSE_DIR="..\\..\\..\\vscode"
 PROGRAM_FILES_86=$( env | sed -n 's/^ProgramFiles(x86)=//p' )
 
 if [[ -z "${1}" ]]; then
-	OUTPUT_BASE_FILENAME="${PRODUCT_NAME}-${VSCODE_ARCH}-${MS_TAG}"
+	OUTPUT_BASE_FILENAME="${PRODUCT_NAME}-${VSCODE_ARCH}-${RELEASE_VERSION}"
 else
-	OUTPUT_BASE_FILENAME="${PRODUCT_NAME}-${VSCODE_ARCH}-${1}-${MS_TAG}"
+	OUTPUT_BASE_FILENAME="${PRODUCT_NAME}-${VSCODE_ARCH}-${1}-${RELEASE_VERSION}"
 fi
 
 if [[ "${VSCODE_ARCH}" == "ia32" ]]; then
@@ -44,15 +44,15 @@ BuildSetupTranslationTransform() {
 	LANGIDS="${LANGIDS},${LANGID}"
 
 	echo "Building setup translation for culture \"${CULTURE}\" with LangID \"${LANGID}\"..."
-	
+
 	"${WIX}bin\\light.exe" vscodium.wixobj "Files-${OUTPUT_BASE_FILENAME}.wixobj" -ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension -spdb -cc "${TEMP}\\vscodium-cab-cache\\${PLATFORM}" -reusecab -out "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.${CULTURE}.msi" -loc "i18n\\${PRODUCT_SKU}.${CULTURE}.wxl" -cultures:"${CULTURE}" -sice:ICE60 -sice:ICE69
-	
+
 	cscript "${PROGRAM_FILES_86}\\Windows Kits\\${WIN_SDK_MAJOR_VERSION}\\bin\\${WIN_SDK_FULL_VERSION}\\${PLATFORM}\\WiLangId.vbs" "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.${CULTURE}.msi" Product "${LANGID}"
-	
+
 	"${PROGRAM_FILES_86}\\Windows Kits\\${WIN_SDK_MAJOR_VERSION}\\bin\\${WIN_SDK_FULL_VERSION}\\x86\\msitran" -g "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.msi" "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.${CULTURE}.msi" "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.${CULTURE}.mst"
-	
+
 	cscript "${PROGRAM_FILES_86}\\Windows Kits\\${WIN_SDK_MAJOR_VERSION}\\bin\\${WIN_SDK_FULL_VERSION}\\${PLATFORM}\\wisubstg.vbs" "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.msi" "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.${CULTURE}.mst" "${LANGID}"
-	
+
 	cscript "${PROGRAM_FILES_86}\\Windows Kits\\${WIN_SDK_MAJOR_VERSION}\\bin\\${WIN_SDK_FULL_VERSION}\\${PLATFORM}\\wisubstg.vbs" "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.msi"
 
 	rm -f "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.${CULTURE}.msi"
@@ -60,7 +60,7 @@ BuildSetupTranslationTransform() {
 }
 
 "${WIX}bin\\heat.exe" dir "${BINARY_DIR}" -out "Files-${OUTPUT_BASE_FILENAME}.wxs" -t vscodium.xsl -gg -sfrag -scom -sreg -srd -ke -cg "AppFiles" -var var.AppName -var var.ProductVersion -var var.IconDir -var var.LicenseDir -var var.BinaryDir -dr APPLICATIONFOLDER -platform "${PLATFORM}"
-"${WIX}bin\\candle.exe" -arch "${PLATFORM}" vscodium.wxs "Files-${OUTPUT_BASE_FILENAME}.wxs" -ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension -dAppName=${PRODUCT_NAME} -dProductVersion="${MS_TAG}" -dProductId="${PRODUCT_ID}" -dBinaryDir="${BINARY_DIR}" -dIconDir="${ICON_DIR}" -dLicenseDir="${LICENSE_DIR}" -dSetupResourcesDir="${SETUP_RESOURCES_DIR}" -dCulture="${CULTURE}"
+"${WIX}bin\\candle.exe" -arch "${PLATFORM}" vscodium.wxs "Files-${OUTPUT_BASE_FILENAME}.wxs" -ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension -dAppName=${PRODUCT_NAME} -dProductVersion="${RELEASE_VERSION}" -dProductId="${PRODUCT_ID}" -dBinaryDir="${BINARY_DIR}" -dIconDir="${ICON_DIR}" -dLicenseDir="${LICENSE_DIR}" -dSetupResourcesDir="${SETUP_RESOURCES_DIR}" -dCulture="${CULTURE}"
 "${WIX}bin\\light.exe" vscodium.wixobj "Files-${OUTPUT_BASE_FILENAME}.wixobj" -ext WixUIExtension -ext WixUtilExtension -ext WixNetFxExtension -spdb -cc "${TEMP}\\vscodium-cab-cache\\${PLATFORM}" -out "${SETUP_RELEASE_DIR}\\${OUTPUT_BASE_FILENAME}.msi" -loc "i18n\\${PRODUCT_SKU}.${CULTURE}.wxl" -cultures:"${CULTURE}" -sice:ICE60 -sice:ICE69
 
 BuildSetupTranslationTransform de-de 1031

--- a/check_cron_or_pr.sh
+++ b/check_cron_or_pr.sh
@@ -4,17 +4,21 @@ set -e
 
 if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
 	echo "It's a PR"
-	
+
 	export SHOULD_BUILD="yes"
 	export SHOULD_DEPLOY="no"
 elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
 	echo "It's a Push"
-	
+
 	export SHOULD_BUILD="yes"
 	export SHOULD_DEPLOY="no"
+elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+	echo "It's a Dispatch"
+
+  export SHOULD_DEPLOY="yes"
 else
-	echo "It's a cron"
-	
+	echo "It's a Cron"
+
 	export SHOULD_DEPLOY="yes"
 fi
 

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -7,8 +7,12 @@ if [[ -z "${GITHUB_TOKEN}" ]]; then
   exit
 fi
 
+VERSIONS_REPO="${GITHUB_USERNAME:-"VSCodium"}/versions"
+https://github.com/${VERSIONS_REPO}.git
+https://raw.githubusercontent.com/${VERSIONS_REPO}/master/darwin/arm64/latest.json
+
 REPOSITORY="${GITHUB_REPOSITORY:-"VSCodium/vscodium"}"
-GITHUB_RESPONSE=$( curl -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPOSITORY}/releases/tags/${MS_TAG}")
+GITHUB_RESPONSE=$( curl -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPOSITORY}/releases/tags/${RELEASE_VERSION}")
 VSCODIUM_ASSETS=$( echo "${GITHUB_RESPONSE}" | jq -c '.assets | map(.name)?' )
 
 contains() {
@@ -19,21 +23,21 @@ contains() {
 if [ "${VSCODIUM_ASSETS}" != "null" ]; then
   # macos
   if [[ "${OS_NAME}" == "osx" ]]; then
-    if [[ -z $( contains "VSCodium-darwin-${VSCODE_ARCH}-${MS_TAG}.zip" ) ]]; then
+    if [[ -z $( contains "VSCodium-darwin-${VSCODE_ARCH}-${RELEASE_VERSION}.zip" ) ]]; then
       echo "Building on MacOS because we have no ZIP"
       export SHOULD_BUILD="yes"
     else
       export SHOULD_BUILD_ZIP="no"
     fi
 
-    if [[ -z $( contains ".${VSCODE_ARCH}.${MS_TAG}.dmg" ) ]]; then
+    if [[ -z $( contains ".${VSCODE_ARCH}.${RELEASE_VERSION}.dmg" ) ]]; then
       echo "Building on MacOS because we have no DMG"
       export SHOULD_BUILD="yes"
     else
       export SHOULD_BUILD_DMG="no"
     fi
 
-    if [[ -z $( contains "vscodium-reh-darwin-${VSCODE_ARCH}-${MS_TAG}.tar.gz" ) ]]; then
+    if [[ -z $( contains "vscodium-reh-darwin-${VSCODE_ARCH}-${RELEASE_VERSION}.tar.gz" ) ]]; then
       echo "Building on MacOS because we have no REH archive"
       export SHOULD_BUILD="yes"
     else
@@ -47,21 +51,21 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
 
     # windows-arm64
     if [[ ${VSCODE_ARCH} == "arm64" ]]; then
-      if [[ -z $( contains "VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe" ) ]]; then
+      if [[ -z $( contains "VSCodiumSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe" ) ]]; then
         echo "Building on Windows arm64 because we have no system setup"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_EXE_SYS="no"
       fi
 
-      if [[ -z $( contains "UserSetup-${VSCODE_ARCH}-${MS_TAG}.exe" ) ]]; then
+      if [[ -z $( contains "UserSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe" ) ]]; then
         echo "Building on Windows arm64 because we have no user setup"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_EXE_USR="no"
       fi
 
-      if [[ -z $( contains "VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip" ) ]]; then
+      if [[ -z $( contains "VSCodium-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.zip" ) ]]; then
         echo "Building on Windows arm64 because we have no zip"
         export SHOULD_BUILD="yes"
       else
@@ -76,42 +80,42 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
 
     # windows-ia32
     elif [[ ${VSCODE_ARCH} == "ia32" ]]; then
-      if [[ -z $( contains "VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe" ) ]]; then
+      if [[ -z $( contains "VSCodiumSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe" ) ]]; then
         echo "Building on Windows ia32 because we have no system setup"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_EXE_SYS="no"
       fi
 
-      if [[ -z $( contains "UserSetup-${VSCODE_ARCH}-${MS_TAG}.exe" ) ]]; then
+      if [[ -z $( contains "UserSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe" ) ]]; then
         echo "Building on Windows ia32 because we have no user setup"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_EXE_USR="no"
       fi
 
-      if [[ -z $( contains "VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip" ) ]]; then
+      if [[ -z $( contains "VSCodium-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.zip" ) ]]; then
         echo "Building on Windows ia32 because we have no zip"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_ZIP="no"
       fi
 
-      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-${MS_TAG}.msi" ) ]]; then
+      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-${RELEASE_VERSION}.msi" ) ]]; then
         echo "Building on Windows ia32 because we have no msi"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_MSI="no"
       fi
 
-      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-updates-disabled-${MS_TAG}.msi" ) ]]; then
+      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-updates-disabled-${RELEASE_VERSION}.msi" ) ]]; then
         echo "Building on Windows ia32 because we have no updates-disabled msi"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_MSI_NOUP="no"
       fi
 
-      if [[ -z $( contains "vscodium-reh-win32-${VSCODE_ARCH}-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "vscodium-reh-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Windows ia32 because we have no REH archive"
         export SHOULD_BUILD="yes"
       else
@@ -124,42 +128,42 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
 
     # windows-x64
     else
-      if [[ -z $( contains "VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe" ) ]]; then
+      if [[ -z $( contains "VSCodiumSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe" ) ]]; then
         echo "Building on Windows x64 because we have no system setup"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_EXE_SYS="no"
       fi
 
-      if [[ -z $( contains "UserSetup-${VSCODE_ARCH}-${MS_TAG}.exe" ) ]]; then
+      if [[ -z $( contains "UserSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe" ) ]]; then
         echo "Building on Windows x64 because we have no user setup"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_EXE_USR="no"
       fi
 
-      if [[ -z $( contains "VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip" ) ]]; then
+      if [[ -z $( contains "VSCodium-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.zip" ) ]]; then
         echo "Building on Windows x64 because we have no zip"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_ZIP="no"
       fi
 
-      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-${MS_TAG}.msi" ) ]]; then
+      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-${RELEASE_VERSION}.msi" ) ]]; then
         echo "Building on Windows x64 because we have no msi"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_MSI="no"
       fi
 
-      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-updates-disabled-${MS_TAG}.msi" ) ]]; then
+      if [[ -z $( contains "VSCodium-${VSCODE_ARCH}-updates-disabled-${RELEASE_VERSION}.msi" ) ]]; then
         echo "Building on Windows x64 because we have no updates-disabled msi"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_MSI_NOUP="no"
       fi
 
-      if [[ -z $( contains "vscodium-reh-win32-${VSCODE_ARCH}-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "vscodium-reh-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Windows x64 because we have no REH archive"
         export SHOULD_BUILD="yes"
       else
@@ -188,14 +192,14 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
         export SHOULD_BUILD_RPM="no"
       fi
 
-      if [[ -z $( contains "VSCodium-linux-arm64-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "VSCodium-linux-arm64-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Linux arm64 because we have no TAR"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_TAR="no"
       fi
 
-      if [[ -z $( contains "vscodium-reh-linux-arm64-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "vscodium-reh-linux-arm64-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Linux arm64 because we have no REH archive"
         export SHOULD_BUILD="yes"
       else
@@ -224,14 +228,14 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
         export SHOULD_BUILD_RPM="no"
       fi
 
-      if [[ -z $( contains "VSCodium-linux-armhf-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "VSCodium-linux-armhf-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Linux arm because we have no TAR"
         export SHOULD_BUILD="yes"
       else
         export SHOULD_BUILD_TAR="no"
       fi
 
-      if [[ -z $( contains "vscodium-reh-linux-armhf-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "vscodium-reh-linux-armhf-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Linux arm because we have no REH archive"
         export SHOULD_BUILD="yes"
       else
@@ -260,7 +264,7 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
         export SHOULD_BUILD_RPM="no"
       fi
 
-      if [[ -z $( contains "VSCodium-linux-x64-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "VSCodium-linux-x64-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Linux x64 because we have no TAR"
         export SHOULD_BUILD="yes"
       else
@@ -274,7 +278,7 @@ if [ "${VSCODIUM_ASSETS}" != "null" ]; then
         export SHOULD_BUILD_APPIMAGE="no"
       fi
 
-      if [[ -z $( contains "vscodium-reh-linux-x64-${MS_TAG}.tar.gz" ) ]]; then
+      if [[ -z $( contains "vscodium-reh-linux-x64-${RELEASE_VERSION}.tar.gz" ) ]]; then
         echo "Building on Linux x64 because we have no REH archive"
         export SHOULD_BUILD="yes"
       else

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+if [[ -z "${RELEASE_VERSION}" ]]; then
+  git fetch --all
+  MS_TAG=$( git tag -l --sort=-version:refname | head -1 )
+  date=$( date +%Y%j )
+  export RELEASE_VERSION="${MS_TAG}.${date: -5}"
+else
+  if [[ "${RELEASE_VERSION}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+$ ]];
+  then
+    MS_TAG="${BASH_REMATCH[1]}"
+  else
+    echo "Bad RELEASE_VERSION: ${RELEASE_VERSION}"
+    exit 1
+  fi
+fi
+
+echo "Release version: ${RELEASE_VERSION}"
+
 mkdir -p vscode
 cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
@@ -41,4 +58,7 @@ cd ..
 if [[ ${GITHUB_ENV} ]]; then
   echo "MS_TAG=${MS_TAG}" >> "${GITHUB_ENV}"
   echo "MS_COMMIT=${MS_COMMIT}" >> "${GITHUB_ENV}"
+  echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_ENV}"
 fi
+
+. version.sh

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# git workaround
+if [[ "${CI_BUILD}" != "no" ]]; then
+  git config --global --add safe.directory /__w/vscodium/vscodium
+fi
+
 if [[ -z "${RELEASE_VERSION}" ]]; then
   git fetch --all
   MS_TAG=$( git tag -l --sort=-version:refname | head -1 )

--- a/patches/build-version.patch
+++ b/patches/build-version.patch
@@ -1,0 +1,158 @@
+diff --git a/build/gulpfile.vscode.linux.js b/build/gulpfile.vscode.linux.js
+index 489d9cc..51db755 100644
+--- a/build/gulpfile.vscode.linux.js
++++ b/build/gulpfile.vscode.linux.js
+@@ -83,7 +83,7 @@ function prepareDebPackage(arch) {
+ 				const dependencies = debianDependenciesGenerator.getDependencies(binaryDir, product.applicationName, debArch, sysroot);
+ 				gulp.src('resources/linux/debian/control.template', { base: '.' })
+ 					.pipe(replace('@@NAME@@', product.applicationName))
+-					.pipe(replace('@@VERSION@@', packageJson.version + '-' + linuxPackageRevision))
++					.pipe(replace('@@VERSION@@', packageJson.version.replace('+', '.')))
+ 					.pipe(replace('@@ARCHITECTURE@@', debArch))
+ 					.pipe(replace('@@DEPENDS@@', dependencies.join(', ')))
+ 					.pipe(replace('@@RECOMMENDS@@', debianRecommendedDependencies.join(', ')))
+@@ -188,8 +188,7 @@ function prepareRpmPackage(arch) {
+ 			.pipe(replace('@@NAME@@', product.applicationName))
+ 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+ 			.pipe(replace('@@ICON@@', product.linuxIconName))
+-			.pipe(replace('@@VERSION@@', packageJson.version))
+-			.pipe(replace('@@RELEASE@@', linuxPackageRevision))
++			.pipe(replace('@@VERSION@@', packageJson.version.replace('+', '.')))
+ 			.pipe(replace('@@ARCHITECTURE@@', rpmArch))
+ 			.pipe(replace('@@LICENSE@@', product.licenseName))
+ 			.pipe(replace('@@QUALITY@@', product.quality || '@@QUALITY@@'))
+@@ -262,7 +261,7 @@ function prepareSnapPackage(arch) {
+ 
+ 		const snapcraft = gulp.src('resources/linux/snap/snapcraft.yaml', { base: '.' })
+ 			.pipe(replace('@@NAME@@', product.applicationName))
+-			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
++			.pipe(replace('@@VERSION@@', packageJson.version.replace('+', '.')))
+ 			// Possible run-on values https://snapcraft.io/docs/architectures
+ 			.pipe(replace('@@ARCHITECTURE@@', arch === 'x64' ? 'amd64' : arch))
+ 			.pipe(rename('snap/snapcraft.yaml'));
+diff --git a/build/gulpfile.vscode.web.js b/build/gulpfile.vscode.web.js
+index 4c1259c..0d41560 100644
+--- a/build/gulpfile.vscode.web.js
++++ b/build/gulpfile.vscode.web.js
+@@ -28,7 +28,7 @@ const WEB_FOLDER = path.join(REPO_ROOT, 'remote', 'web');
+ 
+ const commit = util.getVersion(REPO_ROOT);
+ const quality = product.quality;
+-const version = (quality && quality !== 'stable') ? `${packageJson.version}-${quality}` : packageJson.version;
++const version = (quality && quality !== 'stable') ? `${packageJson.version.replace('+', '.')}-${quality}` : packageJson.version.replace('+', '.');
+ 
+ const vscodeWebResourceIncludes = [
+ 	// Workbench
+diff --git a/build/gulpfile.vscode.win32.js b/build/gulpfile.vscode.win32.js
+index 81ba509..a445749 100644
+--- a/build/gulpfile.vscode.win32.js
++++ b/build/gulpfile.vscode.win32.js
+@@ -91,8 +91,8 @@ function buildWin32Setup(arch, target) {
+ 			NameLong: product.nameLong,
+ 			NameShort: product.nameShort,
+ 			DirName: product.win32DirName,
+-			Version: pkg.version,
+-			RawVersion: pkg.version.replace(/-\w+$/, ''),
++			Version: pkg.version.replace('+', '.'),
++			RawVersion: pkg.version.replace(/-\w+$/, '').replace('+', '.'),
+ 			NameVersion: product.win32NameVersion + (target === 'user' ? ' (User)' : ''),
+ 			ExeBasename: product.nameShort,
+ 			RegValueName: product.win32RegValueName,
+diff --git a/resources/linux/rpm/code.spec.template b/resources/linux/rpm/code.spec.template
+index 00ddb6f..814c964 100644
+--- a/resources/linux/rpm/code.spec.template
++++ b/resources/linux/rpm/code.spec.template
+@@ -1,6 +1,6 @@
+ Name:     @@NAME@@
+ Version:  @@VERSION@@
+-Release:  @@RELEASE@@.el7
++Release:  el7
+ Summary:  Code editing. Redefined.
+ Group:    Development/Tools
+ Vendor:   Microsoft Corporation
+diff --git a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+index 3515dea..c0aa528 100644
+--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
++++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+@@ -23,7 +23,7 @@ import { IFileService } from 'vs/platform/files/common/files';
+ import { ILogService } from 'vs/platform/log/common/log';
+ import { IProductService } from 'vs/platform/product/common/productService';
+ import { asJson, asTextOrError, IRequestService, isSuccess } from 'vs/platform/request/common/request';
+-import { resolveMarketplaceHeaders } from 'vs/platform/externalServices/common/marketplace';
++import { getCoreVersion, resolveMarketplaceHeaders } from 'vs/platform/externalServices/common/marketplace';
+ import { IStorageService } from 'vs/platform/storage/common/storage';
+ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+ 
+@@ -988,7 +988,8 @@ abstract class AbstractExtensionGalleryService implements IExtensionGalleryServi
+ 			return undefined;
+ 		}
+ 
+-		const url = isWeb ? this.api(`/itemName/${publisher}.${name}/version/${version}/statType/${type === StatisticType.Install ? '1' : '3'}/vscodewebextension`) : this.api(`/publishers/${publisher}/extensions/${name}/${version}/stats?statType=${type}`);
++		const coreVersion = getCoreVersion(version);
++		const url = isWeb ? this.api(`/itemName/${publisher}.${name}/version/${coreVersion}/statType/${type === StatisticType.Install ? '1' : '3'}/vscodewebextension`) : this.api(`/publishers/${publisher}/extensions/${name}/${coreVersion}/stats?statType=${type}`);
+ 		const Accept = isWeb ? 'api-version=6.1-preview.1' : '*/*;api-version=4.0-preview.1';
+ 
+ 		const commonHeaders = await this.commonHeadersPromise;
+diff --git a/src/vs/platform/extensions/common/extensionValidator.ts b/src/vs/platform/extensions/common/extensionValidator.ts
+index 0a5e7d2..e453393 100644
+--- a/src/vs/platform/extensions/common/extensionValidator.ts
++++ b/src/vs/platform/extensions/common/extensionValidator.ts
+@@ -9,6 +9,7 @@ import { URI } from 'vs/base/common/uri';
+ import * as nls from 'vs/nls';
+ import * as semver from 'vs/base/common/semver/semver';
+ import { IExtensionManifest } from 'vs/platform/extensions/common/extensions';
++import { getCoreVersion } from 'vs/platform/externalServices/common/marketplace';
+ 
+ export interface IParsedVersion {
+ 	hasCaret: boolean;
+@@ -371,7 +372,8 @@ function isVersionValid(currentVersion: string, date: ProductDate, requestedVers
+ 		}
+ 	}
+ 
+-	if (!isValidVersion(currentVersion, date, desiredVersion)) {
++	const coreVersion = getCoreVersion(currentVersion);
++	if (!isValidVersion(coreVersion, date, desiredVersion)) {
+ 		notices.push(nls.localize('versionMismatch', "Extension is not compatible with Code {0}. Extension requires: {1}.", currentVersion, requestedVersion));
+ 		return false;
+ 	}
+diff --git a/src/vs/platform/externalServices/common/marketplace.ts b/src/vs/platform/externalServices/common/marketplace.ts
+index 5923e1c..a1c9db8 100644
+--- a/src/vs/platform/externalServices/common/marketplace.ts
++++ b/src/vs/platform/externalServices/common/marketplace.ts
+@@ -13,6 +13,10 @@ import { IStorageService } from 'vs/platform/storage/common/storage';
+ import { ITelemetryService, TelemetryLevel } from 'vs/platform/telemetry/common/telemetry';
+ import { getTelemetryLevel, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
+ 
++export function getCoreVersion(version: string): string {
++	return version.replace(/\.[0-9]+$/, '');
++}
++
+ export async function resolveMarketplaceHeaders(version: string,
+ 	productService: IProductService,
+ 	environmentService: IEnvironmentService,
+@@ -20,9 +24,10 @@ export async function resolveMarketplaceHeaders(version: string,
+ 	fileService: IFileService,
+ 	storageService: IStorageService | undefined,
+ 	telemetryService: ITelemetryService): Promise<IHeaders> {
++	const coreVersion = getCoreVersion(version);
+ 	const headers: IHeaders = {
+-		'X-Market-Client-Id': `VSCode ${version}`,
+-		'User-Agent': `VSCode ${version} (${productService.nameShort})`
++		'X-Market-Client-Id': `VSCode ${coreVersion}`,
++		'User-Agent': `VSCode ${coreVersion} (${productService.nameShort})`
+ 	};
+ 	const uuid = await getServiceMachineId(environmentService, fileService, storageService);
+ 	const { sessionId } = await telemetryService.getTelemetryInfo();
+diff --git a/src/vs/platform/product/common/product.ts b/src/vs/platform/product/common/product.ts
+index 7e63a16..767f4f6 100644
+--- a/src/vs/platform/product/common/product.ts
++++ b/src/vs/platform/product/common/product.ts
+@@ -45,7 +45,7 @@ else if (typeof require?.__$__nodeRequire === 'function') {
+ 	}
+ 
+ 	Object.assign(product, {
+-		version: pkg.version
++		version: pkg.version.replace('+', '.')
+ 	});
+ }
+ 

--- a/patches/custom-gallery.patch
+++ b/patches/custom-gallery.patch
@@ -1,36 +1,25 @@
 diff --git a/src/vs/base/common/product.ts b/src/vs/base/common/product.ts
-index f822373..30a0a66 100644
+index 1ae8079..eb56045 100644
 --- a/src/vs/base/common/product.ts
 +++ b/src/vs/base/common/product.ts
-@@ -70,6 +70,7 @@ export interface IProductConfiguration {
- 
- 	readonly extensionsGallery?: {
+@@ -72,2 +72,3 @@ export interface IProductConfiguration {
  		readonly serviceUrl: string;
 +		readonly cacheUrl?: string;
  		readonly itemUrl: string;
- 		readonly publisherUrl: string;
- 		readonly resourceUrlTemplate: string;
 diff --git a/src/vs/platform/product/common/product.ts b/src/vs/platform/product/common/product.ts
 index 7e63a16..3bfeab8 100644
 --- a/src/vs/platform/product/common/product.ts
 +++ b/src/vs/platform/product/common/product.ts
-@@ -4,11 +4,12 @@
-  *--------------------------------------------------------------------------------------------*/
- 
+@@ -6,3 +6,3 @@
  import { FileAccess } from 'vs/base/common/network';
 -import { globals } from 'vs/base/common/platform';
 +import { globals, isWindows } from 'vs/base/common/platform';
  import { env } from 'vs/base/common/process';
- import { IProductConfiguration } from 'vs/base/common/product';
- import { dirname, joinPath } from 'vs/base/common/resources';
+@@ -11,2 +11,3 @@ import { dirname, joinPath } from 'vs/base/common/resources';
  import { ISandboxConfiguration } from 'vs/base/parts/sandbox/common/sandboxTypes';
 +import { getUserDataPath } from 'vs/platform/environment/node/userDataPath';
  
- /**
-  * @deprecated You MUST use `IProductService` if possible.
-@@ -34,6 +35,32 @@ else if (typeof require?.__$__nodeRequire === 'function') {
- 	product = require.__$__nodeRequire(joinPath(rootPath, 'product.json').fsPath);
- 	const pkg = require.__$__nodeRequire(joinPath(rootPath, 'package.json').fsPath) as { version: string };
+@@ -36,2 +37,28 @@ else if (typeof require?.__$__nodeRequire === 'function') {
  
 +	// Merge user-customized product.json
 +	try {
@@ -59,11 +48,7 @@ index 7e63a16..3bfeab8 100644
 +	}
 +
  	// Running out of sources
- 	if (env['VSCODE_DEV']) {
- 		Object.assign(product, {
-@@ -44,6 +71,19 @@ else if (typeof require?.__$__nodeRequire === 'function') {
- 		});
- 	}
+@@ -46,2 +73,15 @@ else if (typeof require?.__$__nodeRequire === 'function') {
  
 +	// Set user-defined extension gallery
 +	const { serviceUrl, cacheUrl, itemUrl, controlUrl, recommendationsUrl } = product.extensionsGallery || {}
@@ -79,5 +64,3 @@ index 7e63a16..3bfeab8 100644
 +	})
 +
  	Object.assign(product, {
- 		version: pkg.version
- 	});

--- a/prepare_artifacts.sh
+++ b/prepare_artifacts.sh
@@ -18,7 +18,7 @@ if [[ "${OS_NAME}" == "osx" ]]; then
   if [[ "${SHOULD_BUILD_ZIP}" != "no" ]]; then
     echo "Building and moving ZIP"
     cd "VSCode-darwin-${VSCODE_ARCH}"
-    zip -r -X -y "../artifacts/VSCodium-darwin-${VSCODE_ARCH}-${MS_TAG}.zip" ./*.app
+    zip -r -X -y "../artifacts/VSCodium-darwin-${VSCODE_ARCH}-${RELEASE_VERSION}.zip" ./*.app
     cd ..
   fi
 
@@ -26,7 +26,7 @@ if [[ "${OS_NAME}" == "osx" ]]; then
     echo "Building and moving DMG"
     pushd "VSCode-darwin-${VSCODE_ARCH}"
     npx create-dmg VSCodium.app ..
-    mv "../VSCodium ${MS_TAG}.dmg" "../artifacts/VSCodium.${VSCODE_ARCH}.${MS_TAG}.dmg"
+    mv "../VSCodium ${RELEASE_VERSION}.dmg" "../artifacts/VSCodium.${VSCODE_ARCH}.${RELEASE_VERSION}.dmg"
     popd
   fi
 
@@ -34,28 +34,28 @@ if [[ "${OS_NAME}" == "osx" ]]; then
 elif [[ "${OS_NAME}" == "windows" ]]; then
   if [[ "${SHOULD_BUILD_ZIP}" != "no" ]]; then
     echo "Moving ZIP"
-    mv "vscode\\.build\\win32-${VSCODE_ARCH}\\archive\\VSCode-win32-${VSCODE_ARCH}.zip" "artifacts\\VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip"
+    mv "vscode\\.build\\win32-${VSCODE_ARCH}\\archive\\VSCode-win32-${VSCODE_ARCH}.zip" "artifacts\\VSCodium-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.zip"
   fi
 
   if [[ "${SHOULD_BUILD_EXE_SYS}" != "no" ]]; then
     echo "Moving System EXE"
-    mv "vscode\\.build\\win32-${VSCODE_ARCH}\\system-setup\\VSCodeSetup.exe" "artifacts\\VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe"
+    mv "vscode\\.build\\win32-${VSCODE_ARCH}\\system-setup\\VSCodeSetup.exe" "artifacts\\VSCodiumSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe"
   fi
 
   if [[ "${SHOULD_BUILD_EXE_USR}" != "no" ]]; then
     echo "Moving User EXE"
-    mv "vscode\\.build\\win32-${VSCODE_ARCH}\\user-setup\\VSCodeSetup.exe" "artifacts\\VSCodiumUserSetup-${VSCODE_ARCH}-${MS_TAG}.exe"
+    mv "vscode\\.build\\win32-${VSCODE_ARCH}\\user-setup\\VSCodeSetup.exe" "artifacts\\VSCodiumUserSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe"
   fi
 
   if [[ "${VSCODE_ARCH}" == "ia32" || "${VSCODE_ARCH}" == "x64" ]]; then
     if [[ "${SHOULD_BUILD_MSI}" != "no" ]]; then
       echo "Moving MSI"
-      mv "build\\windows\\msi\\releasedir\\VSCodium-${VSCODE_ARCH}-${MS_TAG}.msi" artifacts/
+      mv "build\\windows\\msi\\releasedir\\VSCodium-${VSCODE_ARCH}-${RELEASE_VERSION}.msi" artifacts/
     fi
 
     if [[ "${SHOULD_BUILD_MSI_NOUP}" != "no" ]]; then
       echo "Moving MSI with disabled updates"
-      mv "build\\windows\\msi\\releasedir\\VSCodium-${VSCODE_ARCH}-updates-disabled-${MS_TAG}.msi" artifacts/
+      mv "build\\windows\\msi\\releasedir\\VSCodium-${VSCODE_ARCH}-updates-disabled-${RELEASE_VERSION}.msi" artifacts/
     fi
   fi
 
@@ -64,7 +64,7 @@ else
   if [[ "${SHOULD_BUILD_TAR}" != "no" ]]; then
     echo "Building and moving TAR"
     cd "VSCode-linux-${VSCODE_ARCH}"
-    tar czf "../artifacts/VSCodium-linux-${VSCODE_ARCH}-${MS_TAG}.tar.gz" .
+    tar czf "../artifacts/VSCodium-linux-${VSCODE_ARCH}-${RELEASE_VERSION}.tar.gz" .
     cd ..
   fi
 
@@ -89,7 +89,7 @@ fi
 if [[ "${SHOULD_BUILD_REH}" != "no" ]]; then
   echo "Building and moving REH"
   cd "vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
-  tar czf "../artifacts/vscodium-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}-${MS_TAG}.tar.gz" .
+  tar czf "../artifacts/vscodium-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}-${RELEASE_VERSION}.tar.gz" .
   cd ..
 fi
 

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -3,7 +3,7 @@
 set -e
 
 # include common functions
-. ../utils.sh
+. ./utils.sh
 
 cp -rp src/* vscode/
 cp -f LICENSE vscode/LICENSE.txt

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# include common functions
+. ../utils.sh
+
 cp -rp src/* vscode/
 cp -f LICENSE vscode/LICENSE.txt
 

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -93,6 +93,11 @@ rm -f product.json.tmp
 
 cat product.json
 
+mv package.json package.json.bak
+package_json_changes="setpath(["\""version"\""]; "\""${RELEASE_VERSION}"\"")"
+cat package.json.bak | jq "${package_json_changes}" > package.json
+gsed -i -E 's/"version": "(.*)\.([0-9]+)"/"version": "\1+\2"/' package.json
+
 ../undo_telemetry.sh
 
 if [[ "${OS_NAME}" == "linux" ]]; then

--- a/release.sh
+++ b/release.sh
@@ -22,10 +22,6 @@ OWNER="${GITHUB_REPOSITORY_OWNER:-"VSCodium"}"
 REPO_NAME="${GITHUB_REPOSITORY:(${#OWNER}+1)}"
 REPOSITORY="${REPO_NAME:-"vscodium"}"
 
-# git workaround
-git config --global --add safe.directory /__w/vscodium/vscodium
-
-
 for FILE in *
 do
   if [[ -f "${FILE}" ]] && [[ "${FILE}" != *.sha1 ]] && [[ "${FILE}" != *.sha256 ]]; then

--- a/release.sh
+++ b/release.sh
@@ -9,9 +9,9 @@ fi
 
 npm install -g github-release-cli
 
-if [[ $( gh release view "${MS_TAG}" 2>&1 ) =~ "release not found" ]]; then
-  echo "Creating release '${MS_TAG}'"
-  gh release create "${MS_TAG}"
+if [[ $( gh release view "${RELEASE_VERSION}" 2>&1 ) =~ "release not found" ]]; then
+  echo "Creating release '${RELEASE_VERSION}'"
+  gh release create "${RELEASE_VERSION}"
 fi
 
 cd artifacts
@@ -30,7 +30,7 @@ for FILE in *
 do
   if [[ -f "${FILE}" ]] && [[ "${FILE}" != *.sha1 ]] && [[ "${FILE}" != *.sha256 ]]; then
     echo "::group::Uploading '${FILE}' at $( date "+%T" )"
-    gh release upload "${MS_TAG}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+    gh release upload "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
 
     EXIT_STATUS=$?
     echo "exit: ${EXIT_STATUS}"
@@ -38,12 +38,12 @@ do
     if (( "${EXIT_STATUS}" )); then
       for (( i=0; i<10; i++ ))
       do
-        github-release delete --owner "${OWNER}" --repo "${REPOSITORY}" --tag "${MS_TAG}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+        github-release delete --owner "${OWNER}" --repo "${REPOSITORY}" --tag "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
 
         sleep $(( 15 * (i + 1)))
 
         echo "RE-Uploading '${FILE}' at $( date "+%T" )"
-        gh release upload "${MS_TAG}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+        gh release upload "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
 
         EXIT_STATUS=$?
         echo "exit: ${EXIT_STATUS}"
@@ -57,7 +57,7 @@ do
       if (( "${EXIT_STATUS}" )); then
         echo "'${FILE}' hasn't been uploaded!"
 
-        github-release delete --owner "${OWNER}" --repo "${REPOSITORY}" --tag "${MS_TAG}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+        github-release delete --owner "${OWNER}" --repo "${REPOSITORY}" --tag "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
 
         exit 1
       fi

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -5,7 +5,7 @@ DEFAULT_OFF="'default': TelemetryConfiguration.OFF"
 TELEMETRY_CRASH_REPORTER="'telemetry.enableCrashReporter':"
 TELEMETRY_CONFIGURATION=" TelemetryConfiguration.ON"
 
-#include common functions
+# include common functions
 . ../utils.sh
 
 update_setting () {

--- a/update_version.sh
+++ b/update_version.sh
@@ -23,15 +23,15 @@ fi
 #  }
 
 # `url` is URL_BASE + filename of asset e.g.
-#    darwin: https://github.com/VSCodium/vscodium/releases/download/${MS_TAG}/VSCodium-darwin-${MS_TAG}.zip
-# `name` is $MS_TAG
-# `version` is $MS_COMMIT
-# `productVersion` is $MS_TAG
+#    darwin: https://github.com/VSCodium/vscodium/releases/download/${RELEASE_VERSION}/VSCodium-darwin-${RELEASE_VERSION}.zip
+# `name` is $RELEASE_VERSION
+# `version` is $BUILD_SOURCEVERSION
+# `productVersion` is $RELEASE_VERSION
 # `hash` in <filename>.sha1
 # `timestamp` is $(node -e 'console.log(Date.now())')
 # `sha256hash` in <filename>.sha256
 
-URL_BASE="https://github.com/VSCodium/vscodium/releases/download/${MS_TAG}"
+URL_BASE="https://github.com/VSCodium/vscodium/releases/download/${RELEASE_VERSION}"
 
 # to make testing on forks easier
 VERSIONS_REPO="${GITHUB_USERNAME}/versions"
@@ -42,14 +42,14 @@ generateJson() {
 
   # generate parts
   local url="${URL_BASE}/${ASSET_NAME}"
-  local name="${MS_TAG}"
-  local version="${MS_COMMIT}"
-  local productVersion="${MS_TAG}"
+  local name="${RELEASE_VERSION}"
+  local version="${BUILD_SOURCEVERSION}"
+  local productVersion="${RELEASE_VERSION}"
   local timestamp=$(node -e 'console.log(Date.now())')
 
   if [[ ! -f "artifacts/${ASSET_NAME}" ]]; then
     echo "Downloading artifact '${ASSET_NAME}'"
-    gh release download "${MS_TAG}" --dir "artifacts" --pattern "${ASSET_NAME}*"
+    gh release download "${RELEASE_VERSION}" --dir "artifacts" --pattern "${ASSET_NAME}*"
   fi
 
   local sha1hash=$(cat "artifacts/${ASSET_NAME}.sha1" | awk '{ print $1 }')
@@ -101,33 +101,33 @@ git remote add origin "https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${V
 cd ..
 
 if [[ "${OS_NAME}" == "osx" ]]; then
-  ASSET_NAME=VSCodium-darwin-${VSCODE_ARCH}-${MS_TAG}.zip
+  ASSET_NAME=VSCodium-darwin-${VSCODE_ARCH}-${RELEASE_VERSION}.zip
   VERSION_PATH="darwin/${VSCODE_ARCH}"
   updateLatestVersion
 elif [[ "${OS_NAME}" == "windows" ]]; then
   # system installer
-  ASSET_NAME=VSCodiumSetup-${VSCODE_ARCH}-${MS_TAG}.exe
+  ASSET_NAME=VSCodiumSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe
   VERSION_PATH="win32/${VSCODE_ARCH}/system"
   updateLatestVersion
 
   # user installer
-  ASSET_NAME=VSCodiumUserSetup-${VSCODE_ARCH}-${MS_TAG}.exe
+  ASSET_NAME=VSCodiumUserSetup-${VSCODE_ARCH}-${RELEASE_VERSION}.exe
   VERSION_PATH="win32/${VSCODE_ARCH}/user"
   updateLatestVersion
 
   # windows archive
-  ASSET_NAME=VSCodium-win32-${VSCODE_ARCH}-${MS_TAG}.zip
+  ASSET_NAME=VSCodium-win32-${VSCODE_ARCH}-${RELEASE_VERSION}.zip
   VERSION_PATH="win32/${VSCODE_ARCH}/archive"
   updateLatestVersion
 
   if [[ "${VSCODE_ARCH}" == "ia32" || "${VSCODE_ARCH}" == "x64" ]]; then
     # msi
-    ASSET_NAME=VSCodium-${VSCODE_ARCH}-${MS_TAG}.msi
+    ASSET_NAME=VSCodium-${VSCODE_ARCH}-${RELEASE_VERSION}.msi
     VERSION_PATH="win32/${VSCODE_ARCH}/msi"
     updateLatestVersion
 
     # updates-disabled msi
-    ASSET_NAME=VSCodium-${VSCODE_ARCH}-updates-disabled-${MS_TAG}.msi
+    ASSET_NAME=VSCodium-${VSCODE_ARCH}-updates-disabled-${RELEASE_VERSION}.msi
     VERSION_PATH="win32/${VSCODE_ARCH}/msi-updates-disabled"
     updateLatestVersion
   fi
@@ -135,7 +135,7 @@ else # linux
   # update service links to tar.gz file
   # see https://update.code.visualstudio.com/api/update/linux-x64/stable/VERSION
   # as examples
-  ASSET_NAME=VSCodium-linux-${VSCODE_ARCH}-${MS_TAG}.tar.gz
+  ASSET_NAME=VSCodium-linux-${VSCODE_ARCH}-${RELEASE_VERSION}.tar.gz
   VERSION_PATH="linux/${VSCODE_ARCH}"
   updateLatestVersion
 fi

--- a/utils.sh
+++ b/utils.sh
@@ -20,11 +20,11 @@ replace () {
 if ! exists gsed; then
   if is_gnu_sed; then
     function gsed() {
-      sed -i -E "${1}" "${2}"
+      sed -i -E "$@"
     }
   else
     function gsed() {
-      sed -i '' -E "${1}" "${2}"
+      sed -i '' -E "$@"
     }
   fi
 fi

--- a/utils.sh
+++ b/utils.sh
@@ -2,6 +2,8 @@
 
 #All common functions can be added to this file
 
+exists() { type -t "$1" > /dev/null 2>&1; }
+
 is_gnu_sed () {
   sed --version >/dev/null 2>&1
 }
@@ -14,3 +16,15 @@ replace () {
     sed -i '' -E "${1}" "${2}"
   fi
 }
+
+if ! exists gsed; then
+  if is_gnu_sed; then
+    function gsed() {
+      sed -i -E "${1}" "${2}"
+    }
+  else
+    function gsed() {
+      sed -i '' -E "${1}" "${2}"
+    }
+  fi
+fi

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z "${BUILD_SOURCEVERSION}" ]]; then
+
+    npm install -g checksum
+
+    vscodium_hash=$( git rev-parse HEAD )
+
+    cd vscode
+    vscode_hash=$( git rev-parse HEAD )
+    cd ..
+
+    export BUILD_SOURCEVERSION=$( echo "${vscodium_hash}:${vscode_hash}" | checksum )
+
+    echo "Build version: ${BUILD_SOURCEVERSION}"
+
+    # for GH actions
+    if [[ $GITHUB_ENV ]]; then
+        echo "BUILD_SOURCEVERSION=$BUILD_SOURCEVERSION" >> $GITHUB_ENV
+    fi
+fi


### PR DESCRIPTION
This PR adds a release number to each build.

It will allow us to release a new version when we find and correct a bug.
It will also be the base to generate insiders release.

The version number becomes like `1.70.1.22226` with the parts:
- `1.70.1`: the old version number (from VSCode)
- `.`: required separator for MSI, [RPM](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/)
- `22`: the year on 2 digits ([MSI](https://docs.microsoft.com/en-us/windows/win32/msi/productversion) requires a number less than 65,535)
- `226`: the day of year