### PR TITLE
build(linux): use vscode's ripgrep

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -35,7 +35,6 @@
 - dpkg
 - python3
 - imagemagick (for AppImage)
-- ripgrep
 
 ### <a id="dependencies-macos"></a>MacOS
 

--- a/undo_telemetry.sh
+++ b/undo_telemetry.sh
@@ -29,7 +29,7 @@ d1=`date +%s`
 
 if [[ "${OS_NAME}" == "linux" ]]; then
   if [[ ${VSCODE_ARCH} == "x64" ]]; then
-    rg --no-ignore -l "${SEARCH}" . | xargs -I {} bash -c 'replace_with_debug "${1}" "{}"' _ "${REPLACEMENT}"
+    ./node_modules/@vscode/ripgrep/bin/rg --no-ignore -l "${SEARCH}" . | xargs -I {} bash -c 'replace_with_debug "${1}" "{}"' _ "${REPLACEMENT}"
   else
     grep -rl --exclude-dir=.git -E "${SEARCH}" . | xargs -I {} bash -c 'replace_with_debug "${1}" "{}"' _ "${REPLACEMENT}"
   fi


### PR DESCRIPTION
This PR removes the need of the external dependency of ripgrep.