### PR TITLE
ci(snap): re-enable arm64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,7 +113,7 @@ jobs:
       matrix:
         platform:
         - amd64
-        # - arm64
+        - arm64
 
     steps:
       - uses: actions/checkout@v3
@@ -124,27 +124,27 @@ jobs:
           ARCHITECTURE: ${{ matrix.platform }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
 
-      # - uses: docker/setup-qemu-action@v1
-      #   if: env.SHOULD_DEPLOY == 'yes'
+      - uses: docker/setup-qemu-action@v1
+        if: env.SHOULD_DEPLOY == 'yes'
 
-      # - uses: diddlesnaps/snapcraft-multiarch-action@v1
-      #   with:
-      #     path: stores/snapcraft
-      #     architecture: ${{ matrix.platform }}
-      #   id: build
-      #   if: env.SHOULD_DEPLOY == 'yes'
-
-      # - uses: diddlesnaps/snapcraft-review-action@v1
-      #   with:
-      #     snap: ${{ steps.build.outputs.snap }}
-      #     isClassic: 'true'
-      #   if: env.SHOULD_DEPLOY == 'yes'
-      - uses: snapcore/action-build@v1
+      - uses: diddlesnaps/snapcraft-multiarch-action@v1
         with:
           path: stores/snapcraft
+          architecture: ${{ matrix.platform }}
         id: build
         if: env.SHOULD_DEPLOY == 'yes'
 
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: 'true'
+        if: env.SHOULD_DEPLOY == 'yes'
+
+      # - uses: snapcore/action-build@v1
+      #   with:
+      #     path: stores/snapcraft
+      #   id: build
+      #   if: env.SHOULD_DEPLOY == 'yes'
 
       - uses: snapcore/action-publish@master
         env:


### PR DESCRIPTION
This PR reenables the snap for arm64 after the updates:
- https://github.com/diddlesnaps/snapcraft-container/pull/17
- https://github.com/diddlesnaps/snapcraft-multiarch-action/pull/7