### PR TITLE
ci: improve schedule

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: Forced release version
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 7 * * *'
   push:
     branches: [ insider ]
     paths-ignore:

--- a/.github/workflows/insider-macos.yml
+++ b/.github/workflows/insider-macos.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: Forced release version
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 7 * * *'
   push:
     branches: [ insider ]
     paths-ignore:

--- a/.github/workflows/insider-spearhead.yml
+++ b/.github/workflows/insider-spearhead.yml
@@ -3,7 +3,7 @@ name: insider-spearhead
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 0 * * *'
+    - cron: '0 6 * * *'
 
 jobs:
   build:

--- a/.github/workflows/insider-windows.yml
+++ b/.github/workflows/insider-windows.yml
@@ -7,7 +7,7 @@ on:
         type: string
         description: Forced release version
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 7 * * *'
   push:
     branches: [ insider ]
     paths-ignore:

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: Force new Release
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 18 * * *'
   push:
     branches: [ master ]
     paths-ignore:

--- a/.github/workflows/stable-macos.yml
+++ b/.github/workflows/stable-macos.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: Force new Release
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 18 * * *'
   push:
     branches: [ master ]
     paths-ignore:

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -7,7 +7,7 @@ on:
         type: boolean
         description: Force new Release
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 18 * * *'
   push:
     branches: [ master ]
     paths-ignore:


### PR DESCRIPTION
Hi,

I'm moving the schedule of the workflows:
- `stable` at `18:00`. So if there is a breaking change, the fix can be released the next day (if it's at `0:00`, we have to wait for 24h for the next possible release)
- `insider` at `6/7:00`. They are usually in the morning, at bit before that time.