### PR TITLE
feat: show announcements to welcome page

### DIFF
--- a/announcements-builtin.json
+++ b/announcements-builtin.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "new-icon",
+    "title": "💡 Discussion: New icon",
+    "url": "https://github.com/VSCodium/vscodium/discussions/1218"
+  }
+]

--- a/patches/feat-announcements.patch
+++ b/patches/feat-announcements.patch
@@ -4,32 +4,32 @@ index 9564618..35cde81 100644
 +++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
 @@ -116,2 +116,3 @@ type GettingStartedActionEvent = {
  type RecentEntry = (IRecentFolder | IRecentWorkspace) & { id: string };
-+type AnnoucementEntry = { id: string, title: string, url: string };
++type AnnouncementEntry = { id: string, title: string, url: string };
  
 @@ -148,2 +149,4 @@ export class GettingStartedPage extends EditorPane {
  	private gettingStartedList?: GettingStartedIndexList<IResolvedWalkthrough>;
-+	private annoucementList?: GettingStartedIndexList<AnnoucementEntry>;
-+	private annoucementData?: AnnoucementEntry[];
++	private announcementList?: GettingStartedIndexList<AnnouncementEntry>;
++	private announcementData?: AnnouncementEntry[];
  
 @@ -767,2 +770,3 @@ export class GettingStartedPage extends EditorPane {
  		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
-+		const annoucementList = await this.buildAnnoucementList();
++		const announcementList = await this.buildAnnouncementList();
  
 @@ -777,3 +781,3 @@ export class GettingStartedPage extends EditorPane {
  				this.container.classList.remove('noWalkthroughs');
 -				reset(leftColumn, startList.getDomElement(), recentList.getDomElement());
-+				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), annoucementList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), announcementList.getDomElement());
  				reset(rightColumn, gettingStartedList.getDomElement());
 @@ -783,3 +787,3 @@ export class GettingStartedPage extends EditorPane {
  				this.container.classList.add('noWalkthroughs');
 -				reset(leftColumn, startList.getDomElement());
-+				reset(leftColumn, startList.getDomElement(), annoucementList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), announcementList.getDomElement());
  				reset(rightColumn, recentList.getDomElement());
 @@ -930,2 +934,41 @@ export class GettingStartedPage extends EditorPane {
  
-+	private async buildAnnoucementList(): Promise<GettingStartedIndexList<AnnoucementEntry>> {
-+		const renderRecent = (annoucement: AnnoucementEntry) => {
-+			const { title, url } = annoucement;
++	private async buildAnnouncementList(): Promise<GettingStartedIndexList<AnnouncementEntry>> {
++		const renderRecent = (announcement: AnnouncementEntry) => {
++			const { title, url } = announcement;
 +			const li = $('li');
 +
 +			const anchor: HTMLLinkElement = $('a');
@@ -41,29 +41,29 @@ index 9564618..35cde81 100644
 +			return li;
 +		};
 +
-+		if (this.annoucementList) { this.annoucementList.dispose(); }
++		if (this.announcementList) { this.announcementList.dispose(); }
 +
-+		const annoucementList = this.annoucementList = new GettingStartedIndexList({
-+			title: localize('annoucements', "VSCodium Annoucements"),
-+			klass: 'annoucements',
++		const announcementList = this.announcementList = new GettingStartedIndexList({
++			title: localize('announcements', "VSCodium Announcements"),
++			klass: 'announcements',
 +			limit: 5,
-+			empty: $('.empty-recent', {}, localize('noAnnoucements', "There is no annoucements.")),
++			empty: $('.empty-recent', {}, localize('noAnnouncements', "There is no announcements.")),
 +			renderElement: renderRecent,
 +			contextService: this.contextService
 +		});
 +
-+		if (!this.annoucementData) {
++		if (!this.announcementData) {
 +			const branch = this.productService.quality === 'insider' ? 'insider' : 'master';
-+			const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/annoucements.json`);
++			const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/announcements.json`);
 +
 +			if (res.ok) {
-+				this.annoucementData = await res.json() as AnnoucementEntry[];
++				this.announcementData = await res.json() as AnnouncementEntry[];
 +			}
 +		}
 +
-+		annoucementList.setEntries(this.annoucementData);
++		announcementList.setEntries(this.announcementData);
 +
-+		return annoucementList;
++		return announcementList;
 +	}
 +
  	private buildStartList(): GettingStartedIndexList<IWelcomePageStartEntry> {

--- a/patches/feat-announcements.patch
+++ b/patches/feat-announcements.patch
@@ -1,0 +1,69 @@
+diff --git a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+index 9564618..35cde81 100644
+--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
++++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+@@ -116,2 +116,3 @@ type GettingStartedActionEvent = {
+ type RecentEntry = (IRecentFolder | IRecentWorkspace) & { id: string };
++type AnnoucementEntry = { id: string, title: string, url: string };
+ 
+@@ -148,2 +149,4 @@ export class GettingStartedPage extends EditorPane {
+ 	private gettingStartedList?: GettingStartedIndexList<IResolvedWalkthrough>;
++	private annoucementList?: GettingStartedIndexList<AnnoucementEntry>;
++	private annoucementData?: AnnoucementEntry[];
+ 
+@@ -767,2 +770,3 @@ export class GettingStartedPage extends EditorPane {
+ 		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
++		const annoucementList = await this.buildAnnoucementList();
+ 
+@@ -777,3 +781,3 @@ export class GettingStartedPage extends EditorPane {
+ 				this.container.classList.remove('noWalkthroughs');
+-				reset(leftColumn, startList.getDomElement(), recentList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), annoucementList.getDomElement());
+ 				reset(rightColumn, gettingStartedList.getDomElement());
+@@ -783,3 +787,3 @@ export class GettingStartedPage extends EditorPane {
+ 				this.container.classList.add('noWalkthroughs');
+-				reset(leftColumn, startList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), annoucementList.getDomElement());
+ 				reset(rightColumn, recentList.getDomElement());
+@@ -930,2 +934,41 @@ export class GettingStartedPage extends EditorPane {
+ 
++	private async buildAnnoucementList(): Promise<GettingStartedIndexList<AnnoucementEntry>> {
++		const renderRecent = (annoucement: AnnoucementEntry) => {
++			const { title, url } = annoucement;
++			const li = $('li');
++
++			const anchor: HTMLLinkElement = $('a');
++			anchor.href = url;
++			anchor.innerText = title;
++			anchor.target = '_blank';
++			li.appendChild(anchor);
++
++			return li;
++		};
++
++		if (this.annoucementList) { this.annoucementList.dispose(); }
++
++		const annoucementList = this.annoucementList = new GettingStartedIndexList({
++			title: localize('annoucements', "VSCodium Annoucements"),
++			klass: 'annoucements',
++			limit: 5,
++			empty: $('.empty-recent', {}, localize('noAnnoucements', "There is no annoucements.")),
++			renderElement: renderRecent,
++			contextService: this.contextService
++		});
++
++		if (!this.annoucementData) {
++			const branch = this.productService.quality === 'insider' ? 'insider' : 'master';
++			const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/annoucements.json`);
++
++			if (res.ok) {
++				this.annoucementData = await res.json() as AnnoucementEntry[];
++			}
++		}
++
++		annoucementList.setEntries(this.annoucementData);
++
++		return annoucementList;
++	}
++
+ 	private buildStartList(): GettingStartedIndexList<IWelcomePageStartEntry> {

--- a/patches/feat-announcements.patch
+++ b/patches/feat-announcements.patch
@@ -17,17 +17,17 @@ index 9564618..eb8adfe 100644
 +++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
 @@ -116,4 +116,8 @@ type GettingStartedActionEvent = {
  type RecentEntry = (IRecentFolder | IRecentWorkspace) & { id: string };
-+type AnnoucementEntry = { id: string, title: string, url: string };
++type AnnouncementEntry = { id: string, title: string, url: string };
  
  const REDUCED_MOTION_KEY = 'workbench.welcomePage.preferReducedMotion';
 +
-+const BUILTIN_ANNOUNCEMENTS: AnnoucementEntry[] = [/* BUILTIN_ANNOUNCEMENTS */];
++const BUILTIN_ANNOUNCEMENTS: AnnouncementEntry[] = [/* BUILTIN_ANNOUNCEMENTS */];
 +
  export class GettingStartedPage extends EditorPane {
 @@ -148,2 +152,4 @@ export class GettingStartedPage extends EditorPane {
  	private gettingStartedList?: GettingStartedIndexList<IResolvedWalkthrough>;
-+	private annoucementList?: GettingStartedIndexList<AnnoucementEntry>;
-+	private annoucementData?: AnnoucementEntry[];
++	private announcementList?: GettingStartedIndexList<AnnouncementEntry>;
++	private announcementData?: AnnouncementEntry[];
  
 @@ -760,3 +766,2 @@ export class GettingStartedPage extends EditorPane {
  
@@ -35,23 +35,23 @@ index 9564618..eb8adfe 100644
  		const leftColumn = $('.categories-column.categories-column-left', {},);
 @@ -767,2 +772,3 @@ export class GettingStartedPage extends EditorPane {
  		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
-+		const annoucementList = await this.buildAnnoucementList();
++		const announcementList = await this.buildAnnouncementList();
  
 @@ -777,3 +783,3 @@ export class GettingStartedPage extends EditorPane {
  				this.container.classList.remove('noWalkthroughs');
 -				reset(leftColumn, startList.getDomElement(), recentList.getDomElement());
-+				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), annoucementList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), announcementList.getDomElement());
  				reset(rightColumn, gettingStartedList.getDomElement());
 @@ -783,3 +789,3 @@ export class GettingStartedPage extends EditorPane {
  				this.container.classList.add('noWalkthroughs');
 -				reset(leftColumn, startList.getDomElement());
-+				reset(leftColumn, startList.getDomElement(), annoucementList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), announcementList.getDomElement());
  				reset(rightColumn, recentList.getDomElement());
 @@ -930,2 +936,51 @@ export class GettingStartedPage extends EditorPane {
  
-+	private async buildAnnoucementList(): Promise<GettingStartedIndexList<AnnoucementEntry>> {
-+		const renderAnnoucement = (annoucement: AnnoucementEntry) => {
-+			const { title, url } = annoucement;
++	private async buildAnnouncementList(): Promise<GettingStartedIndexList<AnnouncementEntry>> {
++		const renderAnnouncement = (announcement: AnnouncementEntry) => {
++			const { title, url } = announcement;
 +			const li = $('li');
 +
 +			const anchor: HTMLLinkElement = $('a');
@@ -63,39 +63,39 @@ index 9564618..eb8adfe 100644
 +			return li;
 +		};
 +
-+		if (this.annoucementList) { this.annoucementList.dispose(); }
++		if (this.announcementList) { this.announcementList.dispose(); }
 +
-+		const annoucementList = this.annoucementList = new GettingStartedIndexList({
-+			title: localize('annoucements', "VSCodium Annoucements"),
-+			klass: 'annoucements',
++		const announcementList = this.announcementList = new GettingStartedIndexList({
++			title: localize('announcements', "VSCodium Announcements"),
++			klass: 'announcements',
 +			limit: 5,
-+			empty: $('.empty-recent', {}, localize('noAnnoucements', "There are no current annoucements.")),
-+			renderElement: renderAnnoucement,
++			empty: $('.empty-recent', {}, localize('noAnnouncements', "There are no current announcements.")),
++			renderElement: renderAnnouncement,
 +			contextService: this.contextService
 +		});
 +
-+		if (!this.annoucementData) {
++		if (!this.announcementData) {
 +			const showExtras = this.configurationService.getValue<boolean>('workbench.welcomePage.extraAnnouncements');
 +
 +			if (showExtras) {
 +				const branch = this.productService.quality === 'insider' ? 'insider' : 'master';
-+				const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/annoucements-extra.json`);
++				const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/announcements-extra.json`);
 +
 +				if (res.ok) {
-+					var extraAnnouncements = await res.json() as AnnoucementEntry[];
++					var extraAnnouncements = await res.json() as AnnouncementEntry[];
 +
-+					this.annoucementData = [...extraAnnouncements, ...BUILTIN_ANNOUNCEMENTS];
++					this.announcementData = [...extraAnnouncements, ...BUILTIN_ANNOUNCEMENTS];
 +				} else {
-+					this.annoucementData = BUILTIN_ANNOUNCEMENTS;
++					this.announcementData = BUILTIN_ANNOUNCEMENTS;
 +				}
 +			} else {
-+				this.annoucementData = BUILTIN_ANNOUNCEMENTS;
++				this.announcementData = BUILTIN_ANNOUNCEMENTS;
 +			}
 +		}
 +
-+		annoucementList.setEntries(this.annoucementData);
++		announcementList.setEntries(this.announcementData);
 +
-+		return annoucementList;
++		return announcementList;
 +	}
 +
  	private buildStartList(): GettingStartedIndexList<IWelcomePageStartEntry> {

--- a/patches/feat-announcements.patch
+++ b/patches/feat-announcements.patch
@@ -1,35 +1,57 @@
+diff --git a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+index 2c18fde..e1031dd 100644
+--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
++++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+@@ -312,2 +312,8 @@ configurationRegistry.registerConfiguration({
+ 		},
++		'workbench.welcomePage.extraAnnouncements': {
++			scope: ConfigurationScope.MACHINE,
++			type: 'boolean',
++			default: true,
++			description: localize('workbench.welcomePage.extraAnnouncements', "When enabled, the get started page loads additional announcements from VSCodium's repository.")
++		},
+ 		'workbench.startupEditor': {
 diff --git a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
-index 9564618..35cde81 100644
+index 9564618..eb8adfe 100644
 --- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
 +++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
-@@ -116,2 +116,3 @@ type GettingStartedActionEvent = {
+@@ -116,4 +116,8 @@ type GettingStartedActionEvent = {
  type RecentEntry = (IRecentFolder | IRecentWorkspace) & { id: string };
-+type AnnouncementEntry = { id: string, title: string, url: string };
++type AnnoucementEntry = { id: string, title: string, url: string };
  
-@@ -148,2 +149,4 @@ export class GettingStartedPage extends EditorPane {
+ const REDUCED_MOTION_KEY = 'workbench.welcomePage.preferReducedMotion';
++
++const BUILTIN_ANNOUNCEMENTS: AnnoucementEntry[] = [/* BUILTIN_ANNOUNCEMENTS */];
++
+ export class GettingStartedPage extends EditorPane {
+@@ -148,2 +152,4 @@ export class GettingStartedPage extends EditorPane {
  	private gettingStartedList?: GettingStartedIndexList<IResolvedWalkthrough>;
-+	private announcementList?: GettingStartedIndexList<AnnouncementEntry>;
-+	private announcementData?: AnnouncementEntry[];
++	private annoucementList?: GettingStartedIndexList<AnnoucementEntry>;
++	private annoucementData?: AnnoucementEntry[];
  
-@@ -767,2 +770,3 @@ export class GettingStartedPage extends EditorPane {
+@@ -760,3 +766,2 @@ export class GettingStartedPage extends EditorPane {
+ 
+-
+ 		const leftColumn = $('.categories-column.categories-column-left', {},);
+@@ -767,2 +772,3 @@ export class GettingStartedPage extends EditorPane {
  		const gettingStartedList = this.buildGettingStartedWalkthroughsList();
-+		const announcementList = await this.buildAnnouncementList();
++		const annoucementList = await this.buildAnnoucementList();
  
-@@ -777,3 +781,3 @@ export class GettingStartedPage extends EditorPane {
+@@ -777,3 +783,3 @@ export class GettingStartedPage extends EditorPane {
  				this.container.classList.remove('noWalkthroughs');
 -				reset(leftColumn, startList.getDomElement(), recentList.getDomElement());
-+				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), announcementList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), recentList.getDomElement(), annoucementList.getDomElement());
  				reset(rightColumn, gettingStartedList.getDomElement());
-@@ -783,3 +787,3 @@ export class GettingStartedPage extends EditorPane {
+@@ -783,3 +789,3 @@ export class GettingStartedPage extends EditorPane {
  				this.container.classList.add('noWalkthroughs');
 -				reset(leftColumn, startList.getDomElement());
-+				reset(leftColumn, startList.getDomElement(), announcementList.getDomElement());
++				reset(leftColumn, startList.getDomElement(), annoucementList.getDomElement());
  				reset(rightColumn, recentList.getDomElement());
-@@ -930,2 +934,41 @@ export class GettingStartedPage extends EditorPane {
+@@ -930,2 +936,51 @@ export class GettingStartedPage extends EditorPane {
  
-+	private async buildAnnouncementList(): Promise<GettingStartedIndexList<AnnouncementEntry>> {
-+		const renderRecent = (announcement: AnnouncementEntry) => {
-+			const { title, url } = announcement;
++	private async buildAnnoucementList(): Promise<GettingStartedIndexList<AnnoucementEntry>> {
++		const renderAnnoucement = (annoucement: AnnoucementEntry) => {
++			const { title, url } = annoucement;
 +			const li = $('li');
 +
 +			const anchor: HTMLLinkElement = $('a');
@@ -41,29 +63,39 @@ index 9564618..35cde81 100644
 +			return li;
 +		};
 +
-+		if (this.announcementList) { this.announcementList.dispose(); }
++		if (this.annoucementList) { this.annoucementList.dispose(); }
 +
-+		const announcementList = this.announcementList = new GettingStartedIndexList({
-+			title: localize('announcements', "VSCodium Announcements"),
-+			klass: 'announcements',
++		const annoucementList = this.annoucementList = new GettingStartedIndexList({
++			title: localize('annoucements', "VSCodium Annoucements"),
++			klass: 'annoucements',
 +			limit: 5,
-+			empty: $('.empty-recent', {}, localize('noAnnouncements', "There is no announcements.")),
-+			renderElement: renderRecent,
++			empty: $('.empty-recent', {}, localize('noAnnoucements', "There are no current annoucements.")),
++			renderElement: renderAnnoucement,
 +			contextService: this.contextService
 +		});
 +
-+		if (!this.announcementData) {
-+			const branch = this.productService.quality === 'insider' ? 'insider' : 'master';
-+			const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/announcements.json`);
++		if (!this.annoucementData) {
++			const showExtras = this.configurationService.getValue<boolean>('workbench.welcomePage.extraAnnouncements');
 +
-+			if (res.ok) {
-+				this.announcementData = await res.json() as AnnouncementEntry[];
++			if (showExtras) {
++				const branch = this.productService.quality === 'insider' ? 'insider' : 'master';
++				const res = await fetch(`https://raw.githubusercontent.com/VSCodium/vscodium/${branch}/annoucements-extra.json`);
++
++				if (res.ok) {
++					var extraAnnouncements = await res.json() as AnnoucementEntry[];
++
++					this.annoucementData = [...extraAnnouncements, ...BUILTIN_ANNOUNCEMENTS];
++				} else {
++					this.annoucementData = BUILTIN_ANNOUNCEMENTS;
++				}
++			} else {
++				this.annoucementData = BUILTIN_ANNOUNCEMENTS;
 +			}
 +		}
 +
-+		announcementList.setEntries(this.announcementData);
++		annoucementList.setEntries(this.annoucementData);
 +
-+		return announcementList;
++		return annoucementList;
 +	}
 +
  	private buildStartList(): GettingStartedIndexList<IWelcomePageStartEntry> {

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -164,6 +164,9 @@ setpath "package" "release" $( echo "${RELEASE_VERSION}" | sed -n -E "s/^(.*)\.(
 
 replace 's|Microsoft Corporation|VSCodium|' package.json
 
+# announcements
+replace "s|\\[\\/\\* BUILTIN_ANNOUNCEMENTS \\*\\/\\]|$( cat ../announcements-builtin.json | tr -d '\n' )|" src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+
 ../undo_telemetry.sh
 
 replace 's|Microsoft Corporation|VSCodium|' build/lib/electron.js


### PR DESCRIPTION
This PR shows a list of announcements on welcome page with items found in https://github.com/VSCodium/vscodium/blob/insider/annoucements.json (depend on the quality)

@GitMensch @paulcarroty What do you think?