### PR TITLE
fix: use RELEASE_VERSION for BUILD_SOURCEVERSION

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Get version
         env:
           RELEASE_VERSION: ${{ needs.build.outputs.RELEASE_VERSION }}
-        run: echo "PACKAGE_VERSION=${RELEASE_VERSION/-*/}" >> $GITHUB_ENV
+        run: echo "PACKAGE_VERSION=${RELEASE_VERSION/-*/}" >> "${GITHUB_ENV}"
 
       - name: Publish vscodium-insiders-bin
         uses: zokugun/github-actions-aur-releaser@v1

--- a/get_repo.sh
+++ b/get_repo.sh
@@ -103,7 +103,7 @@ git checkout FETCH_HEAD
 cd ..
 
 # for GH actions
-if [[ ${GITHUB_ENV} ]]; then
+if [[ "${GITHUB_ENV}" ]]; then
   echo "MS_TAG=${MS_TAG}" >> "${GITHUB_ENV}"
   echo "MS_COMMIT=${MS_COMMIT}" >> "${GITHUB_ENV}"
   echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_ENV}"

--- a/version.sh
+++ b/version.sh
@@ -2,24 +2,18 @@
 
 if [[ -z "${BUILD_SOURCEVERSION}" ]]; then
 
-    APP_HASH=$( git rev-parse HEAD )
-
-    cd vscode
-    VSCODE_HASH=$( git rev-parse HEAD )
-    cd ..
-
     if type -t "sha1sum" > /dev/null 2>&1; then
-      export BUILD_SOURCEVERSION=$( echo "${APP_HASH}:${VSCODE_HASH}" | sha1sum | cut -d' ' -f1 )
+      export BUILD_SOURCEVERSION=$( echo "${RELEASE_VERSION}" | sha1sum | cut -d' ' -f1 )
     else
       npm install -g checksum
 
-      export BUILD_SOURCEVERSION=$( echo "${APP_HASH}:${VSCODE_HASH}" | checksum )
+      export BUILD_SOURCEVERSION=$( echo "${RELEASE_VERSION}" | checksum )
     fi
 
     echo "BUILD_SOURCEVERSION=\"${BUILD_SOURCEVERSION}\""
 
     # for GH actions
-    if [[ $GITHUB_ENV ]]; then
-        echo "BUILD_SOURCEVERSION=$BUILD_SOURCEVERSION" >> $GITHUB_ENV
+    if [[ "${GITHUB_ENV}" ]]; then
+        echo "BUILD_SOURCEVERSION=${BUILD_SOURCEVERSION}" >> "${GITHUB_ENV}"
     fi
 fi


### PR DESCRIPTION
This PR changes how `BUILD_SOURCEVERSION` is generated.

MS is using the HEAD commit as BUILD_SOURCEVERSION so they have a unique id for each Insider versions which have the same version (for the user).
So when adding the release number, I've just added the HEAD commit of VSCodium to generate the unique id.
But it's unnecessary since we have already an unique id: the RELEASE_VERSION (1.72.2.22286).

Why: https://github.com/jeanp413/open-remote-ssh/issues/25