### PR TITLE
fix: use `setpath_json` for `linkProtectionTrustedDomains`

### DIFF
--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -59,7 +59,7 @@ if [[ "${OS_NAME}" == "osx" ]]; then
   yarn postinstall
 elif [[ "${npm_config_arch}" == "armv7l" || "${npm_config_arch}" == "ia32" ]]; then
   # node-gyp@9.0.0 shipped with node@16.15.0 starts using config.gypi
-  # from the custom headers path if dist-url option was set instead of
+  # from the custom headers path if dist-url option was set, instead of
   # using the config value from the process. Electron builds with pointer compression
   # enabled for x64 and arm64, but incorrectly ships a single copy of config.gypi
   # with v8_enable_pointer_compression option always set for all target architectures.
@@ -94,7 +94,7 @@ setpath "product" "keyboardShortcutsUrlLinux" "https://go.microsoft.com/fwlink/?
 setpath "product" "keyboardShortcutsUrlMac" "https://go.microsoft.com/fwlink/?linkid=832143"
 setpath "product" "keyboardShortcutsUrlWin" "https://go.microsoft.com/fwlink/?linkid=832145"
 setpath "product" "licenseUrl" "https://github.com/VSCodium/vscodium/blob/master/LICENSE"
-setpath "product" "linkProtectionTrustedDomains" '["https://open-vsx.org"]'
+setpath_json "product" "linkProtectionTrustedDomains" '["https://open-vsx.org"]'
 setpath "product" "releaseNotesUrl" "https://go.microsoft.com/fwlink/?LinkID=533483#vscode"
 setpath "product" "reportIssueUrl" "https://github.com/VSCodium/vscodium/issues/new"
 setpath "product" "requestFeatureUrl" "https://go.microsoft.com/fwlink/?LinkID=533482"


### PR DESCRIPTION
since [`setpath`](https://github.com/VSCodium/vscodium/blob/e14a115b0ed8235e78bd492af39ded0eaca74831/prepare_vscode.sh#L74) set everything as `string`s, but `linkProtectionTrustedDomains` is a `string[]`, now we are having this in Trusted Domains:

<details>
<summary>Screenshot version</summary>

![图片](https://user-images.githubusercontent.com/16851802/196098046-f19ad7f5-bfaf-4872-b730-70cca11786fc.png)
</details>


<details open>
<summary>Source code version</summary>

``` JSONc
// By default, VS Code trusts "localhost" as well as the following domains:
// - "["
// - """
// - "h"
// - "t"
// - "t"
// - "p"
// - "s"
// - ":"
// - "/"
// - "/"
// - "o"
// - "p"
// - "e"
// - "n"
// - "-"
// - "v"
// - "s"
// - "x"
// - "."
// - "o"
// - "r"
// - "g"
// - """
// - "]"
```
</details>

The PR fixes this type problem (which lives outside the TypeScript world) by using [`setpath_json`](https://github.com/VSCodium/vscodium/blob/e14a115b0ed8235e78bd492af39ded0eaca74831/prepare_vscode.sh#L80) instead.

---

Also see this, but only if we can have JSON Schema for `product.json`: https://gist.github.com/mikehwang/6ed95480579ac0b9fd72bff340d99a18

---

VSCode source links for reference about how `linkProtectionTrustedDomains` become all those comments in Trusted Domains:

- [`linkProtectionTrustedDomains`][linkProtectionTrustedDomains] got defined in [`IProductConfiguration`][IProductConfiguration] as a `string[]`
- ↓ `linkProtectionTrustedDomains` along with the whole [`product.json`][product.json] got imported as `Partial<IProductConfiguration>` using old school `require()`
- ↓ `Readonly<IProductConfiguration>` got extended to [`IProductService`][IProductService]
- ↓ `productService.linkProtectionTrustedDomains` got concated into [`defaultTrustedDomains`][defaultTrustedDomains] in [`readStaticTrustedDomains()`][readStaticTrustedDomains()]
- `defaultTrustedDomains` got consumed in [`computeTrustedDomainContent()`][computeTrustedDomainContent()], and generates all those comments in Trusted Domains.

[linkProtectionTrustedDomains]: https://github.com/microsoft/vscode/blob/6455bf1608dfa1b955717f66295f0f9200db0f73/src/vs/base/common/product.ts#L156
[IProductConfiguration]: https://github.com/microsoft/vscode/blob/6455bf1608dfa1b955717f66295f0f9200db0f73/src/vs/base/common/product.ts#L33
[product.json]: https://github.com/microsoft/vscode/blob/9db57e76e9f16f552203585a394e50cf0f7a84a7/src/main.js#L26
[IProductService]: https://github.com/microsoft/vscode/blob/6455bf1608dfa1b955717f66295f0f9200db0f73/src/vs/platform/product/common/productService.ts#L11
[defaultTrustedDomains]: https://github.com/microsoft/vscode/blob/a9f9ed2f917387342a7a1ff680ccba2b0ce05515/src/vs/workbench/contrib/url/browser/trustedDomains.ts#L210
[readStaticTrustedDomains()]: https://github.com/microsoft/vscode/blob/a9f9ed2f917387342a7a1ff680ccba2b0ce05515/src/vs/workbench/contrib/url/browser/trustedDomains.ts#L205
[computeTrustedDomainContent()]: https://github.com/microsoft/vscode/blob/a9f9ed2f917387342a7a1ff680ccba2b0ce05515/src/vs/workbench/contrib/url/browser/trustedDomainsFileSystemProvider.ts#L52
