### PR TITLE
Added vscodium-electron package for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ You can always install using the downloads (deb, rpm, tar) on the [releases page
 
 #### <a id="install-on-arch-linux"></a>Install on Arch Linux
 
-VSCodium is available in [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) as package [vscodium-bin](https://aur.archlinux.org/packages/vscodium-bin/), maintained by [@binex-dsk](https://github.com/binex-dsk). An alternative package [vscodium-git](https://aur.archlinux.org/packages/vscodium-git/), maintained by [@cedricroijakkers](https://github.com/cedricroijakkers), is also available should you wish to compile from source yourself.
+VSCodium is available in [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) as package [vscodium-bin](https://aur.archlinux.org/packages/vscodium-bin/), maintained by [@binex-dsk](https://github.com/binex-dsk).  
+If you want to save disk space by having VSCodium use the Electron system-wide, you also have [vscodium-electron](https://aur.archlinux.org/packages/vscodium-electron), maintained by [@m00nw4tch3r](https://aur.archlinux.org/account/m00nw4tch3r).  
+An alternative package [vscodium-git](https://aur.archlinux.org/packages/vscodium-git/), maintained by [@cedricroijakkers](https://github.com/cedricroijakkers), is also available should you wish to compile from source yourself.
 
 #### <a id="flatpak"></a>Flatpak Option (GNU/Linux)
 


### PR DESCRIPTION
Added `vscodium-electron` package to the list of Arch Linux Package providers, in order to give it more visibility!