### PR TITLE
feat: add default apis for open-remote-ssh

### DIFF
--- a/build/update_api.sh
+++ b/build/update_api.sh
@@ -30,4 +30,6 @@ fi
 
 APIS=`cat ${DIRECTORY}/resources/app/product.json | jq -r '.extensionEnabledApiProposals'`
 
+APIS=`echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribViewsRemote"]}'`
+
 cat <<< $(jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json) > product.json

--- a/product.json
+++ b/product.json
@@ -221,6 +221,12 @@
     ],
     "ms-vscode.cpptools": [
       "terminalDataWriteEvent"
+    ],
+    "jeanp413.open-remote-ssh": [
+      "resolvers",
+      "tunnels",
+      "terminalDataWriteEvent",
+      "contribViewsRemote"
     ]
   },
   "extensionKind": {


### PR DESCRIPTION
This PR is adding default apis for [open-remote-ssh](https://open-vsx.org/extension/jeanp413/open-remote-ssh) so it works out of the box.

https://github.com/jeanp413/open-remote-ssh/issues/37