### PR TITLE
Fix broken workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![codium](https://snapcraft.io//codium/badge.svg)](https://snapcraft.io/codium)
 [![codium](https://snapcraft.io//codium/trending.svg?name=0)](https://snapcraft.io/codium)
 
-[![build status (linux)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-linux.yml?branch=master&label=build%20linux)](https://github.com/VSCodium/vscodium/actions/workflows/stable-linux.yml?query=branch%3Amaster)
-[![build status (macos)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-macos.yml?branch=master&label=build%20macOS)](https://github.com/VSCodium/vscodium/actions/workflows/stable-macos.yml?query=branch%3Amaster)
-[![build status (windows)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-windows.yml?branch=master&label=build%20windows)](https://github.com/VSCodium/vscodium/actions/workflows/stable-windows.yml?query=branch%3Amaster)
+[![build status (linux)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-linux.yml?branch=master&label=build%28linux%29)](https://github.com/VSCodium/vscodium/actions/workflows/stable-linux.yml?query=branch%3Amaster)
+[![build status (macos)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-macos.yml?branch=master&label=build%28macOS%29)](https://github.com/VSCodium/vscodium/actions/workflows/stable-macos.yml?query=branch%3Amaster)
+[![build status (windows)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-windows.yml?branch=master&label=build%28windows%29)](https://github.com/VSCodium/vscodium/actions/workflows/stable-windows.yml?query=branch%3Amaster)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![codium](https://snapcraft.io//codium/badge.svg)](https://snapcraft.io/codium)
 [![codium](https://snapcraft.io//codium/trending.svg?name=0)](https://snapcraft.io/codium)
 
-[![build status (linux)](https://img.shields.io/github/workflow/status/VSCodium/vscodium/linux_build/master?label=build%28linux%29)](https://github.com/VSCodium/vscodium/actions/workflows/linux.yml?query=branch%3Amaster)
-[![build status (macos)](https://img.shields.io/github/workflow/status/VSCodium/vscodium/macos_build/master?label=build%28macos%29)](https://github.com/VSCodium/vscodium/actions/workflows/macos.yml?query=branch%3Amaster)
-[![build status (windows)](https://img.shields.io/github/workflow/status/VSCodium/vscodium/windows_build/master?label=build%28windows%29)](https://github.com/VSCodium/vscodium/actions/workflows/windows.yml?query=branch%3Amaster)
+[![build status (linux)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-linux.yml?branch=master&label=build%20linux)](https://github.com/VSCodium/vscodium/actions/workflows/stable-linux.yml?query=branch%3Amaster)
+[![build status (macos)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-macos.yml?branch=master&label=build%20macOS)](https://github.com/VSCodium/vscodium/actions/workflows/stable-macos.yml?query=branch%3Amaster)
+[![build status (windows)](https://img.shields.io/github/actions/workflow/status/VSCodium/vscodium/stable-windows.yml?branch=master&label=build%20windows)](https://github.com/VSCodium/vscodium/actions/workflows/stable-windows.yml?query=branch%3Amaster)
 
 </div>
 


### PR DESCRIPTION

<img width="709" alt="Screenshot 2022-12-30 at 16 37 00" src="https://user-images.githubusercontent.com/649677/210087461-b8e9197d-b675-4676-8251-c6071f13fe25.png">

---

This PR:

- [x] Updates the URLs used for rendering the badges in accordance with the [new format](https://github.com/badges/shields/issues/8671).
- [x] Fixes the URLs of the links on these badges so that they point to the correct workflows.