### PR TITLE
fix: patch mangle for windows

### DIFF
--- a/patches/fix-mangle-windows.patch
+++ b/patches/fix-mangle-windows.patch
@@ -1,0 +1,9 @@
+diff --git a/build/lib/compilation.ts b/build/lib/compilation.ts
+index 2cc04d2c977..9029c6231ed 100644
+--- a/build/lib/compilation.ts
++++ b/build/lib/compilation.ts
+@@ -128,3 +128,3 @@ export function compileTask(src: string, out: string, build: boolean): () => Nod
+ 			mangleStream = es.through(function write(data: File) {
+-				const newContents = newContentsByFileName.get(data.path);
++				const newContents = newContentsByFileName.get(data.path.replace(/\\/g, '/'));
+ 				if (newContents !== undefined) {


### PR DESCRIPTION
This PR adds a patch to fix a mixup when mangling typescript files on Windows.
`esbuild` generates paths with `\` separator while the mangler uses `/`, so the content can't be updated since the paths aren't matching

Fixes https://github.com/jeanp413/open-remote-ssh/issues/44

VSCode doesn't suffer from this issue since the typescript files are compiled once (on Ubuntu) and then shared when the different versions are built for each platform...