### PR TITLE
feat: add command to provide reh url

### DIFF
--- a/patches/insider/add-remote-url.patch
+++ b/patches/insider/add-remote-url.patch
@@ -1,0 +1,23 @@
+diff --git a/src/vs/workbench/contrib/remote/browser/remote.contribution.ts b/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
+index 63e7f2d..e9a6b7d 100644
+--- a/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
++++ b/src/vs/workbench/contrib/remote/browser/remote.contribution.ts
+@@ -13,2 +13,4 @@ import { RemoteStatusIndicator } from 'vs/workbench/contrib/remote/browser/remot
+ import { AutomaticPortForwarding, ForwardedPortsView, PortRestore } from 'vs/workbench/contrib/remote/browser/remoteExplorer';
++import { CommandsRegistry } from 'vs/platform/commands/common/commands';
++import { localize } from 'vs/nls';
+ 
+@@ -23 +25,13 @@ workbenchContributionsRegistry.registerWorkbenchContribution(AutomaticPortForwar
+ workbenchContributionsRegistry.registerWorkbenchContribution(RemoteMarkers, LifecyclePhase.Eventually);
++
++CommandsRegistry.registerCommand({
++	id: 'remote.serverDownloadUrlTemplate',
++	description: {
++		description: localize('remote.serverDownloadUrlTemplate', 'Provides the url template to download the server archive'),
++		args: [],
++		returns: 'string',
++	},
++	handler: async (_) => {
++		return 'https://github.com/VSCodium/vscodium-insiders/releases/download/${version}.${release}-insider/vscodium-reh-${os}-${arch}-${version}.${release}-insider.tar.gz';
++	}
++});


### PR DESCRIPTION
This PR adds a command which provides the download url of the reh archive used by the remote extension.

Associated PR: https://github.com/jeanp413/open-remote-ssh/pull/55