### PR TITLE
Fix MacOS Icon generation

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -38,6 +38,10 @@
 - imagemagick (for AppImage)
 
 ### <a id="dependencies-macos"></a>MacOS
+- imagemagick
+- png2icns (`npm install png2icns -g`)
+- librsvg
+
 
 ### <a id="dependencies-windows"></a>Windows
 

--- a/icons/build_icons.sh
+++ b/icons/build_icons.sh
@@ -33,8 +33,8 @@ VSCODE_PREFIX=""
 
 build_darwin_main() { # {{{
   if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/darwin/code.icns" ]; then
-    rsvg-convert -w 700 -h 700 "icons/${QUALITY}/codium.svg" -o "code_logo.png"
-    composite "code_logo.png" -geometry +165+190 "icons/template_macos.png" "code_1024.png"
+    rsvg-convert -w 655 -h 655 "icons/${QUALITY}/codium.svg" -o "code_logo.png"
+    composite "code_logo.png" -gravity center "icons/template_macos.png" "code_1024.png"
     convert "code_1024.png" -resize 512x512 code_512.png
     convert "code_1024.png" -resize 256x256 code_256.png
     convert "code_1024.png" -resize 128x128 code_128.png


### PR DESCRIPTION
Fix #1456.

With this fix, i've done other things: 
- Made the logo a little smaller because it felt too big in my opinion. I used `-gravity center` instead of `-geometry +<x>+<y>` option to center it.
- added the dependencies needed for icon generation in the build docs, since there weren't there.

## Comparison
Before :
<img width="132" src="https://user-images.githubusercontent.com/79244938/229289222-cc5a9ecc-8a4a-441c-9ae2-54f3b1d92e26.png">

After :
<img width="132" src="https://user-images.githubusercontent.com/79244938/229289235-da778775-3e6d-44b7-8fa2-413380ed181b.png">

**Note** : For some reasons the `png2icns` program didn't work on my machine, so i used the generated pngs instead for the comparison. If you can run it, please do it to see if there is no other issues.