### PR TITLE
Add linux-ppc64le Architecture Support in Build Configuration

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -82,7 +82,7 @@ jobs:
         run: ./get_repo.sh
 
       - uses: docker/setup-qemu-action@v2
-        if: matrix.vscode_arch == 'arm64'
+        if: matrix.vscode_arch == 'arm64' || matrix.vscode_arch == 'ppc64le'
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
@@ -132,6 +132,9 @@ jobs:
         - vscode_arch: arm64
           npm_arch: arm64
           image: vscodium/vscodium-linux-build-agent:buster-arm64
+        - vscode_arch: pp64le
+          npm_arch: ppc64le
+          image: vscodium/vscodium-linux-build-agent:bionic-ppc64le
         # - vscode_arch: armhf
         #   npm_arch: armv7l
         #   image: vscodium/vscodium-linux-build-agent:buster-armhf

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -79,7 +79,7 @@ jobs:
         run: ./get_repo.sh
 
       - uses: docker/setup-qemu-action@v2
-        if: matrix.vscode_arch == 'arm64'
+        if: matrix.vscode_arch == 'arm64' || matrix.vscode_arch == 'ppc64le'
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
@@ -132,6 +132,9 @@ jobs:
         - vscode_arch: armhf
           npm_arch: arm
           image: vscodium/vscodium-linux-build-agent:buster-armhf
+        - vscode_arch: ppc64le
+          npm_arch: ppcc64le
+          image: vscodium/vscodium-linux-build-agent:bionic-ppc64le
     container:
       image: ${{ matrix.image }}
       env:

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,8 @@ if [[ "${SHOULD_BUILD}" == "yes" ]]; then
     fi
 
     VSCODE_PLATFORM="win32"
+  elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then # linux-ppc64le
+    VSCODE_PLATFORM="linux"
   else # linux
     yarn gulp "vscode-linux-${VSCODE_ARCH}-min-ci"
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -49,6 +49,8 @@ UNAME_ARCH=$( uname -m )
 
 if [[ "${UNAME_ARCH}" == "arm64" ]]; then
   export VSCODE_ARCH="arm64"
+elif [[ "${UNAME_ARCH}" == "ppc64le" ]]; then
+  export VSCODE_ARCH="ppc64le"
 else
   export VSCODE_ARCH="x64"
 fi

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -282,6 +282,24 @@ if [ "${ASSETS}" != "null" ]; then
         echo "Already have all the Linux arm builds"
       fi
 
+    # linux-ppc64le
+    elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
+      SHOULD_BUILD_DEB="no"
+      SHOULD_BUILD_APPIMAGE="no"
+      SHOULD_BUILD_RPM="no"
+      SHOULD_BUILD_TAR="no"
+
+      if [[ -z $( contains "${APP_NAME_LC}-reh-linux-ppc64le-${RELEASE_VERSION}.tar.gz" ) ]]; then
+        echo "Building on Linux PowerPC64LE because we have no REH archive"
+        export SHOULD_BUILD="yes"
+      else
+        export SHOULD_BUILD_REH="no"
+      fi
+
+      if [[ "${SHOULD_BUILD}" != "yes" ]]; then
+        echo "Already have all the Linux PowerPC64LE builds"
+      fi
+
     # linux-x64
     else
       if [[ -z $( contains "amd64.deb" ) ]]; then

--- a/patches/ppc64le-support.patch
+++ b/patches/ppc64le-support.patch
@@ -1,0 +1,264 @@
+diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
+index 2a0c236eaf0..be2528c5c48 100644
+--- a/build/gulpfile.reh.js
++++ b/build/gulpfile.reh.js
+@@ -46,6 +46,7 @@ const BUILD_TARGETS = [
+ 	{ platform: 'linux', arch: 'x64' },
+ 	{ platform: 'linux', arch: 'armhf' },
+ 	{ platform: 'linux', arch: 'arm64' },
++	{ platform: 'linux', arch: 'ppc64le' },
+ 	{ platform: 'alpine', arch: 'arm64' },
+ 	// legacy: we use to ship only one alpine so it was put in the arch, but now we ship
+ 	// multiple alpine images and moved to a better model (alpine as the platform)
+diff --git a/build/gulpfile.scan.js b/build/gulpfile.scan.js
+index 62691fcc8cf..dbefb8549f1 100644
+--- a/build/gulpfile.scan.js
++++ b/build/gulpfile.scan.js
+@@ -24,6 +24,7 @@ const BUILD_TARGETS = [
+ 	{ platform: 'linux', arch: 'x64' },
+ 	{ platform: 'linux', arch: 'armhf' },
+ 	{ platform: 'linux', arch: 'arm64' },
++	{ platform: 'linux', arch: 'ppc64le' },
+ ];
+ 
+ BUILD_TARGETS.forEach(buildTarget => {
+diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
+index 0ca2cfd60a9..18a60efc405 100644
+--- a/build/gulpfile.vscode.js
++++ b/build/gulpfile.vscode.js
+@@ -426,6 +426,7 @@ const BUILD_TARGETS = [
+ 	{ platform: 'linux', arch: 'x64' },
+ 	{ platform: 'linux', arch: 'armhf' },
+ 	{ platform: 'linux', arch: 'arm64' },
++	{ platform: 'linux', arch: 'ppc64le' },
+ ];
+ BUILD_TARGETS.forEach(buildTarget => {
+ 	const dashed = (str) => (str ? `-${str}` : ``);
+diff --git a/build/gulpfile.vscode.linux.js b/build/gulpfile.vscode.linux.js
+index 90f75ccfabd..a9fe7715da9 100644
+--- a/build/gulpfile.vscode.linux.js
++++ b/build/gulpfile.vscode.linux.js
+@@ -29,7 +29,7 @@ const linuxPackageRevision = Math.floor(new Date().getTime() / 1000);
+  * @param {string} arch
+  */
+ function getDebPackageArch(arch) {
+-	return { x64: 'amd64', armhf: 'armhf', arm64: 'arm64' }[arch];
++	return { x64: 'amd64', armhf: 'armhf', arm64: 'arm64', ppc64le: 'ppc64le' }[arch];
+ }
+ 
+ function prepareDebPackage(arch) {
+@@ -136,7 +136,7 @@ function getRpmBuildPath(rpmArch) {
+  * @param {string} arch
+  */
+ function getRpmPackageArch(arch) {
+-	return { x64: 'x86_64', armhf: 'armv7hl', arm64: 'aarch64' }[arch];
++	return { x64: 'x86_64', armhf: 'armv7hl', arm64: 'aarch64', ppc64le: 'ppc64le' }[arch];
+ }
+ 
+ /**
+@@ -292,6 +292,7 @@ const BUILD_TARGETS = [
+ 	{ arch: 'x64' },
+ 	{ arch: 'armhf' },
+ 	{ arch: 'arm64' },
++	{ arch: 'ppc64le' },
+ ];
+ 
+ BUILD_TARGETS.forEach(({ arch }) => {
+diff --git a/build/linux/debian/calculate-deps.ts b/build/linux/debian/calculate-deps.ts
+index b13d3cdfaaf..650e4de3894 100644
+--- a/build/linux/debian/calculate-deps.ts
++++ b/build/linux/debian/calculate-deps.ts
+@@ -52,6 +52,9 @@ function calculatePackageDeps(binaryPath: string, arch: DebianArchString, sysroo
+ 		case 'arm64':
+ 			cmd.push(`-l${sysroot}/usr/lib/aarch64-linux-gnu`,
+ 				`-l${sysroot}/lib/aarch64-linux-gnu`);
++		case 'ppc64le':
++			cmd.push(`-l${sysroot}/usr/lib/ppc64le-linux-gnu`,
++				`-l${sysroot}/lib/ppc64le-linux-gnu`);
+ 			break;
+ 	}
+ 	cmd.push(`-l${sysroot}/usr/lib`);
+diff --git a/build/linux/debian/dep-lists.ts b/build/linux/debian/dep-lists.ts
+index 52aa56d960b..857589ec9ff 100644
+--- a/build/linux/debian/dep-lists.ts
++++ b/build/linux/debian/dep-lists.ts
+@@ -136,5 +136,44 @@ export const referenceGeneratedDepsByArch = {
+ 		'libxkbfile1',
+ 		'libxrandr2',
+ 		'xdg-utils (>= 1.0.2)'
++	],
++	'ppc64le': [
++		'ca-certificates',
++		'libasound2 (>= 1.0.17)',
++		'libatk-bridge2.0-0 (>= 2.5.3)',
++		'libatk1.0-0 (>= 2.2.0)',
++		'libatspi2.0-0 (>= 2.9.90)',
++		'libc6 (>= 2.17)',
++		'libc6 (>= 2.28)',
++		'libcairo2 (>= 1.6.0)',
++		'libcurl3-gnutls | libcurl3-nss | libcurl4 | libcurl3',
++		'libdbus-1-3 (>= 1.0.2)',
++		'libdrm2 (>= 2.4.60)',
++		'libexpat1 (>= 2.0.1)',
++		'libgbm1 (>= 17.1.0~rc2)',
++		'libglib2.0-0 (>= 2.16.0)',
++		'libglib2.0-0 (>= 2.39.4)',
++		'libgtk-3-0 (>= 3.9.10)',
++		'libgtk-3-0 (>= 3.9.10) | libgtk-4-1',
++		'libnspr4 (>= 2:4.9-2~)',
++		'libnss3 (>= 2:3.22)',
++		'libnss3 (>= 3.26)',
++		'libpango-1.0-0 (>= 1.14.0)',
++		'libsecret-1-0 (>= 0.18)',
++		'libstdc++6 (>= 4.1.1)',
++		'libstdc++6 (>= 5)',
++		'libstdc++6 (>= 5.2)',
++		'libstdc++6 (>= 6)',
++		'libx11-6',
++		'libx11-6 (>= 2:1.4.99.1)',
++		'libxcb1 (>= 1.9.2)',
++		'libxcomposite1 (>= 1:0.4.4-1)',
++		'libxdamage1 (>= 1:1.1)',
++		'libxext6',
++		'libxfixes3',
++		'libxkbcommon0 (>= 0.4.1)',
++		'libxkbfile1',
++		'libxrandr2',
++		'xdg-utils (>= 1.0.2)'
+ 	]
+ };
+diff --git a/build/linux/debian/types.ts b/build/linux/debian/types.ts
+index e97485ef128..356027a648b 100644
+--- a/build/linux/debian/types.ts
++++ b/build/linux/debian/types.ts
+@@ -3,8 +3,8 @@
+  *  Licensed under the MIT License. See License.txt in the project root for license information.
+  *--------------------------------------------------------------------------------------------*/
+ 
+-export type DebianArchString = 'amd64' | 'armhf' | 'arm64';
++export type DebianArchString = 'amd64' | 'armhf' | 'arm64' | 'ppc64le';
+ 
+ export function isDebianArchString(s: string): s is DebianArchString {
+-	return ['amd64', 'armhf', 'arm64'].includes(s);
++	return ['amd64', 'armhf', 'arm64', 'ppc64le'].includes(s);
+ }
+diff --git a/cli/src/update_service.rs b/cli/src/update_service.rs
+index b03d8ea5963..2beceeac640 100644
+--- a/cli/src/update_service.rs
++++ b/cli/src/update_service.rs
+@@ -209,6 +209,7 @@ pub enum Platform {
+ 	LinuxX64,
+ 	LinuxARM64,
+ 	LinuxARM32,
++	LinuxPPC64LE,
+ 	DarwinX64,
+ 	DarwinARM64,
+ 	WindowsX64,
+@@ -222,6 +223,7 @@ impl Platform {
+ 			Platform::LinuxX64 => Some("linux-x64".to_owned()),
+ 			Platform::LinuxARM64 => Some("linux-arm64".to_owned()),
+ 			Platform::LinuxARM32 => Some("linux-armhf".to_owned()),
++			Platform::LinuxPPC64LE => Some("linux-ppc64le".to_owned()),
+ 			Platform::DarwinX64 => Some("darwin".to_owned()),
+ 			Platform::DarwinARM64 => Some("darwin-arm64".to_owned()),
+ 			Platform::WindowsX64 => Some("win32-x64-archive".to_owned()),
+@@ -237,6 +239,7 @@ impl Platform {
+ 			Platform::LinuxX64 => "server-linux-x64",
+ 			Platform::LinuxARM64 => "server-linux-arm64",
+ 			Platform::LinuxARM32 => "server-linux-armhf",
++			Platform::LinuxPPC64LE => "server-linux-ppc64le",
+ 			Platform::DarwinX64 => "server-darwin",
+ 			Platform::DarwinARM64 => "server-darwin-arm64",
+ 			Platform::WindowsX64 => "server-win32-x64",
+@@ -253,6 +256,7 @@ impl Platform {
+ 			Platform::LinuxX64 => "cli-linux-x64",
+ 			Platform::LinuxARM64 => "cli-linux-arm64",
+ 			Platform::LinuxARM32 => "cli-linux-armhf",
++			Platform::LinuxPPC64LE => "cli-linux-ppc64le",
+ 			Platform::DarwinX64 => "cli-darwin-x64",
+ 			Platform::DarwinARM64 => "cli-darwin-arm64",
+ 			Platform::WindowsARM64 => "cli-win32-arm64",
+@@ -285,6 +289,8 @@ impl Platform {
+ 			Some(Platform::LinuxARM32)
+ 		} else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+ 			Some(Platform::LinuxARM64)
++		} else if cfg!(all(target_os = "linux", target_arch = "ppc64le")) {
++			Some(Platform::LinuxPPC64LE)
+ 		} else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+ 			Some(Platform::DarwinX64)
+ 		} else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+@@ -309,6 +315,7 @@ impl fmt::Display for Platform {
+ 			Platform::LinuxX64 => "LinuxX64",
+ 			Platform::LinuxARM64 => "LinuxARM64",
+ 			Platform::LinuxARM32 => "LinuxARM32",
++			Platform::LinuxPPC64LE => "LinuxPPC64LE",
+ 			Platform::DarwinX64 => "DarwinX64",
+ 			Platform::DarwinARM64 => "DarwinARM64",
+ 			Platform::WindowsX64 => "WindowsX64",
+diff --git a/cli/src/util/prereqs.rs b/cli/src/util/prereqs.rs
+index d8cbd1b91dd..191d312e994 100644
+--- a/cli/src/util/prereqs.rs
++++ b/cli/src/util/prereqs.rs
+@@ -64,6 +64,8 @@ impl PreReqChecker {
+ 				Platform::LinuxX64
+ 			} else if cfg!(target_arch = "arm") {
+ 				Platform::LinuxARM32
++			} else if cfg!(target_arch = "ppc64le") {
++				Platform::LinuxPPC64LE
+ 			} else {
+ 				Platform::LinuxARM64
+ 			});
+diff --git a/src/main.js b/src/main.js
+index d986fee6f6d..02cd26a4d93 100644
+--- a/src/main.js
++++ b/src/main.js
+@@ -405,6 +405,7 @@ function configureCrashReporter() {
+ 						}
+ 					}
+ 				} else if (isLinux) {
++
+ 					submitURL = appCenter['linux-x64'];
+ 				}
+ 				submitURL = submitURL.concat('&uid=', crashReporterId, '&iid=', crashReporterId, '&sid=', crashReporterId);
+diff --git a/src/vs/platform/extensionManagement/common/extensionManagement.ts b/src/vs/platform/extensionManagement/common/extensionManagement.ts
+index d407374f6ee..636da84fd62 100644
+--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
++++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
+@@ -28,6 +28,7 @@ export function TargetPlatformToString(targetPlatform: TargetPlatform) {
+ 		case TargetPlatform.LINUX_X64: return 'Linux 64 bit';
+ 		case TargetPlatform.LINUX_ARM64: return 'Linux ARM 64';
+ 		case TargetPlatform.LINUX_ARMHF: return 'Linux ARM';
++		case TargetPlatform.LINUX_PPC64LE: return 'Linux PPC64LE';
+ 
+ 		case TargetPlatform.ALPINE_X64: return 'Alpine Linux 64 bit';
+ 		case TargetPlatform.ALPINE_ARM64: return 'Alpine ARM 64';
+@@ -52,6 +53,7 @@ export function toTargetPlatform(targetPlatform: string): TargetPlatform {
+ 		case TargetPlatform.LINUX_X64: return TargetPlatform.LINUX_X64;
+ 		case TargetPlatform.LINUX_ARM64: return TargetPlatform.LINUX_ARM64;
+ 		case TargetPlatform.LINUX_ARMHF: return TargetPlatform.LINUX_ARMHF;
++		case TargetPlatform.LINUX_PPC64LE: return TargetPlatform.LINUX_PPC64LE;
+ 
+ 		case TargetPlatform.ALPINE_X64: return TargetPlatform.ALPINE_X64;
+ 		case TargetPlatform.ALPINE_ARM64: return TargetPlatform.ALPINE_ARM64;
+@@ -90,6 +92,9 @@ export function getTargetPlatform(platform: Platform | 'alpine', arch: string |
+ 			if (arch === 'arm') {
+ 				return TargetPlatform.LINUX_ARMHF;
+ 			}
++			if (arch === 'ppc64le') {
++				return TargetPlatform.LINUX_PPC64LE;
++			}
+ 			return TargetPlatform.UNKNOWN;
+ 
+ 		case 'alpine':
+diff --git a/src/vs/platform/extensions/common/extensions.ts b/src/vs/platform/extensions/common/extensions.ts
+index cfa0e3296f0..d38a82114e3 100644
+--- a/src/vs/platform/extensions/common/extensions.ts
++++ b/src/vs/platform/extensions/common/extensions.ts
+@@ -296,6 +296,7 @@ export const enum TargetPlatform {
+ 	LINUX_X64 = 'linux-x64',
+ 	LINUX_ARM64 = 'linux-arm64',
+ 	LINUX_ARMHF = 'linux-armhf',
++	LINUX_PPC64LE = 'linux-ppc64le',
+ 
+ 	ALPINE_X64 = 'alpine-x64',
+ 	ALPINE_ARM64 = 'alpine-arm64',


### PR DESCRIPTION
# Summary

This pull request introduces support for building VSCodium on the **`linux-ppc64le`** platform.

# Changes

A new build target for the **`linux-ppc64le`** platform has been added to `gulpfile.reh.js`:

```javascript
{ platform: 'linux', arch: 'ppc64le' },
```

# Motivation

The `linux-ppc64le` (PowerPC 64-bit Little Endian) platform is commonly used in high-performance computing environments and by the scientific community. There have been numerous requests for Microsoft's VSCode to support this platform, but progress has been slow. By adding support for `linux-ppc64le` in VSCodium, we are satisfying a previously unfulfilled need within the community. This not only serves those who have been requesting this feature but also makes VSCodium more accessible to those using this architecture in scientific and research contexts.


# Testing

Before merging this pull request, it's important to test the build process on a linux-ppc64le system to ensure the functionality works as expected. Any volunteers or guidance on accomplishing this would be greatly appreciated.

