### PR TITLE
Fix typo in stable-linux

### DIFF
--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -133,7 +133,7 @@ jobs:
           npm_arch: arm
           image: vscodium/vscodium-linux-build-agent:buster-armhf
         - vscode_arch: ppc64le
-          npm_arch: ppcc64le
+          npm_arch: ppc64le
           image: vscodium/vscodium-linux-build-agent:bionic-ppc64le
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
Found that some node packages like `@vscode/ripgrep` had x64 binaries. Traced the issue back to my typo.
