### PR TITLE
Fix incorret npm_config_arch for ppc64le

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -133,7 +133,7 @@ jobs:
           npm_arch: arm64
           image: vscodium/vscodium-linux-build-agent:buster-arm64
         - vscode_arch: pp64le
-          npm_arch: ppc64le
+          npm_arch: ppc64
           image: vscodium/vscodium-linux-build-agent:bionic-ppc64le
         - vscode_arch: armhf
           npm_arch: arm

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -133,7 +133,7 @@ jobs:
           npm_arch: arm
           image: vscodium/vscodium-linux-build-agent:buster-armhf
         - vscode_arch: ppc64le
-          npm_arch: ppc64le
+          npm_arch: ppc64
           image: vscodium/vscodium-linux-build-agent:bionic-ppc64le
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
After the last PR I submitted (#1544), I noticed that the issue with node modules targeting Intel hadn't gone away. After some more careful debugging, I identified the root cause as a difference in the architecture string used to target PowerPC64LE (I was using `ppc64le`, while the expected was `ppc64`).

The line showing the correct string for this is [microsoft/vscode-ripgrep/lib/postinstall.js#L45](https://github.com/microsoft/vscode-ripgrep/blob/643b34e570da705a357ed1edff3f60d3bab4c780/lib/postinstall.js#L45):

```javascript
arch === 'ppc64' ? 'powerpc64le-unknown-linux-gnu' :
```

I've corrected the workflow YAMLs to make use of the proper architecture.

**I must express my sincere apologies for any inconvenience caused due to my previous oversights.**

To make sure that the issue gone, I made some local builds using `export npm_config_arch=ppc64` and have confirmed that there are no more node modules with binaries targeting the wrong architecture.

Once again, I'm sorry for the confusion and thank you for your understanding.