### PR TITLE
fix: disable update on linux

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -117,6 +117,7 @@ jobs:
       - dependencies
     runs-on: ubuntu-latest
     env:
+      DISABLE_UPDATE: 'yes'
       MS_COMMIT: ${{ needs.check.outputs.MS_COMMIT }}
       MS_TAG: ${{ needs.check.outputs.MS_TAG }}
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -114,6 +114,7 @@ jobs:
       - dependencies
     runs-on: ubuntu-latest
     env:
+      DISABLE_UPDATE: 'yes'
       MS_COMMIT: ${{ needs.check.outputs.MS_COMMIT }}
       MS_TAG: ${{ needs.check.outputs.MS_TAG }}
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
Hi,

This PR is disabling the update check on linux.
Unlike macOS or Windows, there is no automatic update. When an update available, it's redirecting to the `.tar.gz` however it was installed.
Most users would have installed VSCodium with a package manager. In that case, the update check isn't needed. And it will most likely be in conflict with the package manager. (download `.tar.gz` instead of showing the package manager)
If the user have install it directly from the `.tar.gz`, `.rpm` or `.deb`, it will need to check manually for an update. I think it should be fine for any power user.

@paulcarroty @GitMensch @geekley @DanielProg39 @mndscp @evur Could I have your opinion? Thx