### PR TITLE
Optimizations for shell scripts

### DIFF
--- a/build/update_api.sh
+++ b/build/update_api.sh
@@ -1,23 +1,25 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
 export VSCODE_QUALITY="stable"
 
-while getopts ":ilp" opt; do
+while getopts ":i" opt; do
   case "$opt" in
     i)
       export VSCODE_QUALITY="insider"
+      ;;
+    *)
       ;;
   esac
 done
 
 
-URL=`curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/VERSION" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/'`
+URL=$(curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/VERSION" |  grep -oP '(?<="url":")[^"]+(?=")')
 # echo "url: ${URL}"
-FILE=`echo "${URL}" | sed -E 's|.*/([^/]+\.zip)$|\1|'`
+FILE="${URL##*/}"
 # echo "file: ${FILE}"
-DIRECTORY=`echo "${URL}" | sed -E 's|.*/([^/]+)\.zip$|\1|'`
+DIRECTORY="${FILE%.zip}"
 # echo "directory: ${DIRECTORY}"
 
 if [[ ! -f "${FILE}" ]]; then
@@ -28,8 +30,9 @@ if [[ ! -d "${DIRECTORY}" ]]; then
   unzip "${FILE}" -d "${DIRECTORY}"
 fi
 
-APIS=`cat ${DIRECTORY}/resources/app/product.json | jq -r '.extensionEnabledApiProposals'`
+APIS=$(jq -r '.extensionEnabledApiProposals' "${DIRECTORY}"/resources/app/product.json)
 
-APIS=`echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribRemoteHelp", "contribViewsRemote"]}'`
+APIS=$(echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribRemoteHelp", "contribViewsRemote"]}')
 
-cat <<< $(jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json) > product.json
+jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json > temp.json
+mv -f temp.json product.json

--- a/build/update_patches.sh
+++ b/build/update_patches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export VSCODE_QUALITY="stable"
 
@@ -16,10 +16,9 @@ git add .
 git reset -q --hard HEAD
 
 for FILE in ../patches/*.patch; do
-  if [ -f "${FILE}" ]; then
+  if [[ -f "${FILE}" ]]; then
     echo applying patch: "${FILE}"
-    git apply --ignore-whitespace "${FILE}"
-    if [ $? -ne 0 ]; then
+    if ! git apply --ignore-whitespace "${FILE}"; then
       echo failed to apply patch "${FILE}"
 
       git apply --reject "${FILE}"
@@ -38,10 +37,9 @@ done
 
 if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
   for FILE in ../patches/insider/*.patch; do
-    if [ -f "${FILE}" ]; then
+    if [[ -f "${FILE}" ]]; then
       echo applying patch: "${FILE}"
-      git apply --ignore-whitespace "${FILE}"
-      if [ $? -ne 0 ]; then
+      if ! git apply --ignore-whitespace "${FILE}"; then
         echo failed to apply patch "${FILE}"
 
         git apply --reject "${FILE}"

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -21,10 +21,9 @@ cd vscode || { echo "'vscode' dir not found"; exit 1; }
 { set +x; } 2>/dev/null
 
 for file in ../patches/*.patch; do
-  if [ -f "${file}" ]; then
+  if [[ -f "${file}" ]]; then
     echo applying patch: "${file}";
-    git apply --ignore-whitespace "${file}"
-    if [ $? -ne 0 ]; then
+    if ! git apply --ignore-whitespace "${file}"; then
       echo failed to apply patch "${file}" 1>&2
     fi
   fi
@@ -32,10 +31,9 @@ done
 
 if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
   for file in ../patches/insider/*.patch; do
-    if [ -f "${file}" ]; then
+    if [[ -f "${file}" ]]; then
       echo applying patch: "${file}";
-      git apply --ignore-whitespace "${file}"
-      if [ $? -ne 0 ]; then
+      if ! git apply --ignore-whitespace "${file}"; then
         echo failed to apply patch "${file}" 1>&2
       fi
     fi
@@ -43,10 +41,9 @@ if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
 fi
 
 for file in ../patches/user/*.patch; do
-  if [ -f "${file}" ]; then
+  if [[ -f "${file}" ]]; then
     echo applying user patch: "${file}";
-    git apply --ignore-whitespace "${file}"
-    if [ $? -ne 0 ]; then
+    if ! git apply --ignore-whitespace "${file}"; then
       echo failed to apply patch "${file}" 1>&2
     fi
   fi


### PR DESCRIPTION
1. Clarify return code parsing. 
    `if ! git apply --ignore-whitespace "${FILE}"; then` 
instead of 
    `git apply --ignore-whitespace "${FILE}";
    if [ $? -ne 0 ]; then`
2. Standardize shebang. Currently all `.sh` files have either `#!/bin/bash` or `/usr/bin/env bash`. Practically this has no effect, however if I'm there, I'm going to change it the preferred `#!/usr/bin/env bash`.
3. Standardize tests. Currently most `.sh` files have a mixture of `[ ]` and `[[ ]]` tests. The bash tests are potentially faster, and since it doesn't appear POSIX compatibility is a requirement I've updated them.

This is the tip of the iceberg for these types of optimizations, but I want to gauge interest in this type of contribution.