### PR TITLE
Apply shellcheck to all vscodium shell scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2129
 
 ### Windows
 # to run with Bash: "C:\Program Files\Git\bin\bash.exe" ./build/build.sh
@@ -13,7 +14,7 @@ export SKIP_SOURCE="no"
 export VSCODE_LATEST="no"
 export VSCODE_QUALITY="stable"
 
-while getopts ":ilop" opt; do
+while getopts ":ilops" opt; do
   case "$opt" in
     i)
       export VSCODE_QUALITY="insider"
@@ -29,6 +30,8 @@ while getopts ":ilop" opt; do
       ;;
     s)
       export SKIP_SOURCE="yes"
+      ;;
+    *)
       ;;
   esac
 done
@@ -100,7 +103,8 @@ if [[ "${SKIP_BUILD}" == "no" ]]; then
   . build.sh
 
   if [[ "${VSCODE_QUALITY}" == "insider" && "${VSCODE_LATEST}" == "yes" ]]; then
-    echo "$( cat "insider.json" | jq --arg 'tag' "${MS_TAG/\-insider/}" --arg 'commit' "${MS_COMMIT}" '. | .tag=$tag | .commit=$commit' )" > "insider.json"
+    jsonTmp=$( jq --arg 'tag' "${MS_TAG/\-insider/}" --arg 'commit' "${MS_COMMIT}" '. "insider.json" | .tag=$tag | .commit=$commit' )
+    echo "${jsonTmp}" > "insider.json" && unset jsonTmp
   fi
 fi
 

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
 
-exists() { type -t "$1" > /dev/null 2>&1; }
+exists() { type -t "$1" &> /dev/null; }
 
 export APP_NAME="VSCodium"
 export CI_BUILD="no"
@@ -19,7 +20,9 @@ while getopts ":ilp" opt; do
       export VSCODE_LATEST="yes"
       ;;
     p)
-      export SKIP_ASSETS="no"
+      export SKIP_ASSETS="no" 
+      ;;
+    *)
       ;;
   esac
 done

--- a/build/linux/appimage/build.sh
+++ b/build/linux/appimage/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
@@ -15,11 +15,11 @@ if [[ "${VSCODE_ARCH}" == "x64" ]]; then
     exit 1
   fi
 
-  wget -c "${APPIMAGE_URL}"
+wget -c "${APPIMAGE_URL}" -o pkg2appimage.AppImage
 
-  chmod +x ./pkg2appimage-*.AppImage
+chmod +x ./pkg2appimage.AppImage
 
-  ./pkg2appimage-*.AppImage --appimage-extract && mv ./squashfs-root ./pkg2appimage.AppDir
+./pkg2appimage.AppImage --appimage-extract && mv ./squashfs-root ./pkg2appimage.AppDir
 
   # add update's url
   sed -i 's/generate_type2_appimage/generate_type2_appimage -u "gh-releases-zsync|VSCodium|vscodium|latest|*.AppImage.zsync"/' pkg2appimage.AppDir/AppRun

--- a/build/update_api.sh
+++ b/build/update_api.sh
@@ -1,23 +1,25 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
 export VSCODE_QUALITY="stable"
 
-while getopts ":ilp" opt; do
+while getopts ":i" opt; do
   case "$opt" in
     i)
       export VSCODE_QUALITY="insider"
+      ;;
+    *)
       ;;
   esac
 done
 
 
-URL=`curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/VERSION" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/'`
+URL=$( curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/VERSION" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/' )
 # echo "url: ${URL}"
-FILE=`echo "${URL}" | sed -E 's|.*/([^/]+\.zip)$|\1|'`
+FILE=$( echo "${URL}" | sed -E 's|.*/([^/]+\.zip)$|\1|' )
 # echo "file: ${FILE}"
-DIRECTORY=`echo "${URL}" | sed -E 's|.*/([^/]+)\.zip$|\1|'`
+DIRECTORY=$( echo "${URL}" | sed -E 's|.*/([^/]+)\.zip$|\1|' )
 # echo "directory: ${DIRECTORY}"
 
 if [[ ! -f "${FILE}" ]]; then
@@ -28,8 +30,9 @@ if [[ ! -d "${DIRECTORY}" ]]; then
   unzip "${FILE}" -d "${DIRECTORY}"
 fi
 
-APIS=`cat ${DIRECTORY}/resources/app/product.json | jq -r '.extensionEnabledApiProposals'`
+APIS=$( jq -r '.extensionEnabledApiProposals' "${DIRECTORY}/resources/app/product.json" )
 
-APIS=`echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribRemoteHelp", "contribViewsRemote"]}'`
+APIS=$( echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribRemoteHelp", "contribViewsRemote"]}' )
 
-cat <<< $(jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json) > product.json
+jsonTmp=$(jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json)
+echo "${jsonTmp}" > product.json && unset jsonTmp

--- a/build/update_api.sh
+++ b/build/update_api.sh
@@ -15,11 +15,11 @@ while getopts ":i" opt; do
 done
 
 
-URL=$( curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/VERSION" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/' )
+URL=$( curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/0000000000000000000000000000000000000000" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/' )
 # echo "url: ${URL}"
-FILE=$( echo "${URL}" | sed -E 's|.*/([^/]+\.zip)$|\1|' )
+FILE="${URL##*/}"
 # echo "file: ${FILE}"
-DIRECTORY=$( echo "${URL}" | sed -E 's|.*/([^/]+)\.zip$|\1|' )
+DIRECTORY="${FILE%.zip}"
 # echo "directory: ${DIRECTORY}"
 
 if [[ ! -f "${FILE}" ]]; then
@@ -34,5 +34,5 @@ APIS=$( jq -r '.extensionEnabledApiProposals' "${DIRECTORY}/resources/app/produc
 
 APIS=$( echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribRemoteHelp", "contribViewsRemote"]}' )
 
-jsonTmp=$(jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json)
+jsonTmp=$( jq --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json )
 echo "${jsonTmp}" > product.json && unset jsonTmp

--- a/build/update_patches.sh
+++ b/build/update_patches.sh
@@ -1,11 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export VSCODE_QUALITY="stable"
 
-while getopts ":ilp" opt; do
+while getopts ":i" opt; do
   case "$opt" in
     i)
       export VSCODE_QUALITY="insider"
+      ;;
+    *)
       ;;
   esac
 done
@@ -16,16 +18,15 @@ git add .
 git reset -q --hard HEAD
 
 for FILE in ../patches/*.patch; do
-  if [ -f "${FILE}" ]; then
+  if [[ -f "${FILE}" ]]; then
     echo applying patch: "${FILE}"
-    git apply --ignore-whitespace "${FILE}"
-    if [ $? -ne 0 ]; then
+    if ! git apply --ignore-whitespace "${FILE}"; then
       echo failed to apply patch "${FILE}"
 
       git apply --reject "${FILE}"
       git apply --reject "../patches/helper/settings.patch"
 
-      read -p "Press any key when the conflict have been resolved..." -n1 -s
+      read -rp "Press any key when the conflict have been resolved..." -n1 -s
 
       git restore .vscode/settings.json
       git add .
@@ -38,16 +39,15 @@ done
 
 if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
   for FILE in ../patches/insider/*.patch; do
-    if [ -f "${FILE}" ]; then
+    if [[ -f "${FILE}" ]]; then
       echo applying patch: "${FILE}"
-      git apply --ignore-whitespace "${FILE}"
-      if [ $? -ne 0 ]; then
+      if ! git apply --ignore-whitespace "${FILE}"; then
         echo failed to apply patch "${FILE}"
 
         git apply --reject "${FILE}"
         git apply --reject "../patches/helper/settings.patch"
 
-        read -p "Press any key when the conflict have been resolved..." -n1 -s
+        read -rp "Press any key when the conflict have been resolved..." -n1 -s
 
         git restore .vscode/settings.json
         git add .

--- a/build/windows/msi/build-updates-disabled.sh
+++ b/build/windows/msi/build-updates-disabled.sh
@@ -10,9 +10,8 @@ SCRIPT_DIR=$( pwd )
 
 cd "../../../VSCode-win32-${VSCODE_ARCH}/resources/app"
 
-cp product.json product.json.bak
-jq "del(.updateUrl)" product.json.bak > product.json
-rm -f product.json.bak
+jsonTmp=$( jq "del(.updateUrl)" product.json )
+echo "${jsonTmp}" > product.json && unset jsonTmp
 
 cd "${SCRIPT_DIR}"
 

--- a/build/windows/msi/build-updates-disabled.sh
+++ b/build/windows/msi/build-updates-disabled.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
@@ -11,7 +11,7 @@ SCRIPT_DIR=$( pwd )
 cd "../../../VSCode-win32-${VSCODE_ARCH}/resources/app"
 
 cp product.json product.json.bak
-cat product.json.bak | jq "del(.updateUrl)" > product.json
+jq "del(.updateUrl)" product.json.bak > product.json
 rm -f product.json.bak
 
 cd "${SCRIPT_DIR}"

--- a/build/windows/msi/build.sh
+++ b/build/windows/msi/build.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
 
 set -ex
 
@@ -12,14 +11,12 @@ WIN_SDK_FULL_VERSION="10.0.17763.0"
 
 if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
   PRODUCT_NAME="VSCodium - Insiders"
-  PRODUCT_SKU="vscodium-insiders"
   PRODUCT_CODE="VSCodiumInsiders"
   PRODUCT_UPGRADE_CODE="1C9B7195-5A9A-43B3-B4BD-583E20498467"
   ICON_DIR="..\\..\\..\\src\\insider\\resources\\win32"
   SETUP_RESOURCES_DIR=".\\resources\\insider"
 else
   PRODUCT_NAME="VSCodium"
-  PRODUCT_SKU="vscodium"
   PRODUCT_CODE="VSCodium"
   PRODUCT_UPGRADE_CODE="965370CD-253C-4720-82FC-2E6B02A53808"
   ICON_DIR="..\\..\\..\\src\\stable\\resources\\win32"

--- a/build/windows/msi/build.sh
+++ b/build/windows/msi/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 set -ex
 

--- a/build/windows/rtf/make.sh
+++ b/build/windows/rtf/make.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../../vscode || { echo "'vscode' dir not found"; exit 1; }
 

--- a/icons/build_icons.sh
+++ b/icons/build_icons.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 
 set -e
 
@@ -14,14 +15,14 @@ while getopts ":i" opt; do
       export QUALITY="insider"
       export COLOR="orange1"
       ;;
+    *)
+      ;;
   esac
 done
 
 check_programs() { # {{{
-  for arg in "$@"
-  do
-    if ! command -v "${arg}" >/dev/null 2>&1
-    then
+  for arg in "$@"; do
+    if ! command -v "${arg}" &> /dev/null; then
       echo "${arg} could not be found"
       exit
     fi
@@ -52,9 +53,8 @@ build_darwin_main() { # {{{
 build_darwin_types() { # {{{
   rsvg-convert -w 128 -h 128 "icons/${QUALITY}/codium_cnl_w80_b8.svg" -o "code_logo.png"
 
-  for file in "${VSCODE_PREFIX}"vscode/resources/darwin/*
-  do
-    if [ -f "${file}" ]; then
+  for file in "${VSCODE_PREFIX}"vscode/resources/darwin/*; do
+    if [[ -f "${file}" ]]; then
       name=$(basename "${file}" '.icns')
 
       if [[ ${name} != 'code' ]] && [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/darwin/${name}.icns" ]; then
@@ -76,26 +76,26 @@ build_darwin_types() { # {{{
 } # }}}
 
 build_linux_main() { # {{{
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/linux/code.png" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/linux/code.png" ]]; then
     wget "https://raw.githubusercontent.com/VSCodium/icons/main/icons/linux/circle1/${COLOR}/paulo22s.png" -O "${SRC_PREFIX}src/${QUALITY}/resources/linux/code.png"
   fi
 
   mkdir -p "${SRC_PREFIX}src/${QUALITY}/resources/linux/rpm"
 
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/linux/rpm/code.xpm" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/linux/rpm/code.xpm" ]]; then
     convert "${SRC_PREFIX}src/${QUALITY}/resources/linux/code.png" "${SRC_PREFIX}src/${QUALITY}/resources/linux/rpm/code.xpm"
   fi
 } # }}}
 
 build_media() { # {{{
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/src/vs/workbench/browser/media/code-icon.svg" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/src/vs/workbench/browser/media/code-icon.svg" ]]; then
     cp "icons/${QUALITY}/codium_clt.svg" "${SRC_PREFIX}src/${QUALITY}/src/vs/workbench/browser/media/code-icon.svg"
     gsed -i 's|width="100" height="100"|width="1024" height="1024"|' "${SRC_PREFIX}src/${QUALITY}/src/vs/workbench/browser/media/code-icon.svg"
   fi
 } # }}}
 
 build_windows_main() { # {{{
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/code.ico" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/code.ico" ]]; then
     wget "https://raw.githubusercontent.com/VSCodium/icons/main/icons/win32/nobg/${COLOR}/paulo22s.ico" -O "${SRC_PREFIX}src/${QUALITY}/resources/win32/code.ico"
   fi
 } # }}}
@@ -105,9 +105,8 @@ build_windows_types() { # {{{
 
   rsvg-convert -b "#F5F6F7" -w 64 -h 64 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
 
-  for file in "${VSCODE_PREFIX}"vscode/resources/win32/*.ico
-  do
-    if [ -f "${file}" ]; then
+  for file in "${VSCODE_PREFIX}"vscode/resources/win32/*.ico; do
+    if [[ -f "${file}" ]]; then
       name=$(basename "${file}" '.ico')
 
       if [[ ${name} != 'code' ]] && [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/${name}.ico" ]; then
@@ -122,95 +121,95 @@ build_windows_types() { # {{{
     fi
   done
 
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_70x70.png" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_70x70.png" ]]; then
     convert -size 70x70 canvas:transparent PNG32:"${SRC_PREFIX}src/${QUALITY}/resources/win32/code_70x70.png"
     rsvg-convert -w 45 -h 45 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_70x70.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_70x70.png"
   fi
 
-   if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_150x150.png" ]; then
+   if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_150x150.png" ]]; then
     convert -size 150x150 canvas:transparent PNG32:"${SRC_PREFIX}src/${QUALITY}/resources/win32/code_150x150.png"
     rsvg-convert -w 64 -h 64 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -geometry +44+25 "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_150x150.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/code_150x150.png"
   fi
 
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-100.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-100.bmp" ]]; then
     convert -size 164x314 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-100.bmp"
     rsvg-convert -w 126 -h 126 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-100.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-100.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-125.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-125.bmp" ]]; then
     convert -size 192x386 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-125.bmp"
     rsvg-convert -w 147 -h 147 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-125.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-125.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-150.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-150.bmp" ]]; then
     convert -size 246x459 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-150.bmp"
     rsvg-convert -w 190 -h 190 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-150.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-150.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-175.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-175.bmp" ]]; then
     convert -size 273x556 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-175.bmp"
     rsvg-convert -w 211 -h 211 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-175.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-175.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-200.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-200.bmp" ]]; then
     convert -size 328x604 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-200.bmp"
     rsvg-convert -w 255 -h 255 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-200.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-200.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-225.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-225.bmp" ]]; then
     convert -size 355x700 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-225.bmp"
     rsvg-convert -w 273 -h 273 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-225.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-225.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-250.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-250.bmp" ]]; then
     convert -size 410x797 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-250.bmp"
     rsvg-convert -w 317 -h 317 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-250.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-big-250.bmp"
   fi
 
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-100.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-100.bmp" ]]; then
     convert -size 55x55 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-100.bmp"
     rsvg-convert -w 44 -h 44 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-100.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-100.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-125.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-125.bmp" ]]; then
     convert -size 64x68 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-125.bmp"
     rsvg-convert -w 52 -h 52 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-125.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-125.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-150.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-150.bmp" ]]; then
     convert -size 83x80 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-150.bmp"
     rsvg-convert -w 63 -h 63 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-150.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-150.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-175.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-175.bmp" ]]; then
     convert -size 92x97 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-175.bmp"
     rsvg-convert -w 76 -h 76 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-175.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-175.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-200.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-200.bmp" ]]; then
     convert -size 110x106 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-200.bmp"
     rsvg-convert -w 86 -h 86 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-200.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-200.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-225.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-225.bmp" ]]; then
     convert -size 119x123 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-225.bmp"
     rsvg-convert -w 103 -h 103 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-225.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-225.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-250.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-250.bmp" ]]; then
     convert -size 138x140 xc:white "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-250.bmp"
     rsvg-convert -w 116 -h 116 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -gravity center "code_logo.png" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-250.bmp" "${SRC_PREFIX}src/${QUALITY}/resources/win32/inno-small-250.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-banner.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-banner.bmp" ]]; then
     convert -size 493x58 xc:white "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-banner.bmp"
     rsvg-convert -w 50 -h 50 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -geometry +438+6 "code_logo.png" "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-banner.bmp" "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-banner.bmp"
   fi
-  if [ ! -f "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-dialog.bmp" ]; then
+  if [[ ! -f "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-dialog.bmp" ]]; then
     convert -size 493x312 xc:white "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-dialog.bmp"
     rsvg-convert -w 120 -h 120 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
     composite -geometry +22+152 "code_logo.png" "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-dialog.bmp" "${SRC_PREFIX}build/windows/msi/resources/${QUALITY}/wix-dialog.bmp"
@@ -219,8 +218,7 @@ build_windows_types() { # {{{
   rm code_logo.png
 } # }}}
 
-if [ "${0}" == "${BASH_SOURCE}" ];
-then
+if [[ "${0}" == "${BASH_SOURCE[0]}" ]]; then
   build_darwin_main
   build_linux_main
   build_windows_main

--- a/stores/snapcraft/check_version.sh
+++ b/stores/snapcraft/check_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -12,11 +12,11 @@ sudo snap install --channel stable --classic snapcraft
 
 echo "Architecture: ${ARCHITECTURE}"
 
-SNAP_VERSION=$(snapcraft list-revisions ${SNAP_NAME} | grep -F "stable*" | grep "${ARCHITECTURE}" | tr -s ' ' | cut -d ' ' -f 4)
+SNAP_VERSION=$( snapcraft list-revisions "${SNAP_NAME}" | grep -F "stable*" | grep "${ARCHITECTURE}" | tr -s ' ' | cut -d ' ' -f 4 )
 echo "Snap version: ${SNAP_VERSION}"
 
 wget --quiet "https://api.github.com/repos/${ASSETS_REPOSITORY}/releases" -O gh_latest.json
-GH_VERSION=$(jq -r 'sort_by(.tag_name)|last.tag_name' gh_latest.json)
+GH_VERSION=$( jq -r 'sort_by(.tag_name)|last.tag_name' gh_latest.json )
 echo "GH version: ${GH_VERSION}"
 
 rm -f gh_latest.json
@@ -27,7 +27,7 @@ else
   export SHOULD_DEPLOY="yes"
 
   snap version
-  snap info "${SNAP_NAME}" | true
+  snap info "${SNAP_NAME}" || true
 fi
 
 if [[ "${GITHUB_ENV}" ]]; then

--- a/stores/winget/check_version.sh
+++ b/stores/winget/check_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -120,7 +120,7 @@ cd "${REPOSITORY_NAME}" || { echo "'${REPOSITORY_NAME}' dir not found"; exit 1; 
 git config user.email "$( echo "${GITHUB_USERNAME}" | awk '{print tolower($0)}' )-ci@not-real.com"
 git config user.name "${GITHUB_USERNAME} CI"
 git remote rm origin
-git remote add origin "https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${VERSIONS_REPOSITORY}.git" > /dev/null 2>&1
+git remote add origin "https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${VERSIONS_REPOSITORY}.git" &> /dev/null
 cd ..
 
 if [[ "${OS_NAME}" == "osx" ]]; then

--- a/utils.sh
+++ b/utils.sh
@@ -2,10 +2,10 @@
 
 # All common functions can be added to this file
 
-exists() { type -t "$1" > /dev/null 2>&1; }
+exists() { type -t "$1" &> /dev/null; }
 
 is_gnu_sed () {
-  sed --version >/dev/null 2>&1
+  sed --version &> /dev/null
 }
 
 replace () {

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 
 if [[ -z "${BUILD_SOURCEVERSION}" ]]; then
 
-    if type -t "sha1sum" > /dev/null 2>&1; then
+    if type -t "sha1sum" &> /dev/null; then
       BUILD_SOURCEVERSION=$( echo "${RELEASE_VERSION/-*/}" | sha1sum | cut -d' ' -f1 )
     else
       npm install -g checksum


### PR DESCRIPTION
All shell scripts within the `VSCodium` repository's now pass `shellcheck`.

1. Fixed glob used in command name ( [https://github.com/VSCodium/vscodium/issues/1570](https://github.com/VSCodium/vscodium/issues/1570) ).
2. Fixed typo causing logical error piping into `true` ( [https://github.com/VSCodium/vscodium/issues/1570](https://github.com/VSCodium/vscodium/issues/1570) ).
3. Fixed options specified in `getopts` but not handled by case statement [https://www.shellcheck.net/wiki/SC2213](https://www.shellcheck.net/wiki/SC2213)
4. Handled invalid flags ( with implied continue ) in case statements ( [https://www.shellcheck.net/wiki/SC2220](https://www.shellcheck.net/wiki/SC2220) ).
5. Read error codes directly (style) ( [https://www.shellcheck.net/wiki/SC2181](https://www.shellcheck.net/wiki/SC2181) ).
6. Fixed all instances of reading/writing files in same pipeline ([https://www.shellcheck.net/wiki/SC2094](https://www.shellcheck.net/wiki/SC2094)).
8. Removed legacy back-ticks ( used `$( command )` with spaces) ([https://www.shellcheck.net/wiki/SC2006](https://www.shellcheck.net/wiki/SC2006)).
9. Removed useless `cat` ([https://www.shellcheck.net/wiki/SC2002](https://www.shellcheck.net/wiki/SC2002)).
10. Added `-r` to `read` commands ([https://www.shellcheck.net/wiki/SC2162](https://www.shellcheck.net/wiki/SC2162)).


Special `shellcheck` considerations:
1. `shellcheck` recommends many style changes for both readability and consistency ( both subjective ). Where applicable I've ignored these messages to conform with the style preference of the project. One example is: [https://www.shellcheck.net/wiki/SC2129](https://www.shellcheck.net/wiki/SC2129)  
2. `shellcheck` notes when it is unable to follow variables or files when sourced. When applicable, I ignored this message ([https://www.shellcheck.net/wiki/SC1091](https://www.shellcheck.net/wiki/SC1091)) with a directive ([https://github.com/koalaman/shellcheck/wiki/directive](https://github.com/koalaman/shellcheck/wiki/directive)).
3. I believe the `shellcheck` disable messages are a value add, because they cut down on the noise when searching for actual errors.

Other small changes:
1. I standardized all `> /dev/null 2>&1` to simply `&> /dev/null`. I found it both ways and chose the latter.
2. I standardized newlines in `if` statements and `for` loops.
3. I standardized all shebangs with `#!/usr/bin/env bash`.
4. I standardized all tests with `[[ ]]`.