### PR TITLE
fix: bump snap base to core22

### DIFF
--- a/stores/snapcraft/stable/snap/snapcraft.yaml
+++ b/stores/snapcraft/stable/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Code editing. Redefined.
 description: |
   Binary releases of Code without branding/telemetry/licensing
 
-base: core18
+base: core22
 grade: stable
 confinement: classic
 compression: lzo


### PR DESCRIPTION
I don't know if that still builds. Just want to remove `core18` dependency from my system.