### PR TITLE
Reduce Global Variable Assignment

### DIFF
--- a/icons/build_icons.sh
+++ b/icons/build_icons.sh
@@ -21,6 +21,7 @@ while getopts ":i" opt; do
 done
 
 check_programs() { # {{{
+  local arg
   for arg in "$@"; do
     if ! command -v "${arg}" &> /dev/null; then
       echo "${arg} could not be found"
@@ -51,11 +52,12 @@ build_darwin_main() { # {{{
 } # }}}
 
 build_darwin_types() { # {{{
+  local file name
   rsvg-convert -w 128 -h 128 "icons/${QUALITY}/codium_cnl_w80_b8.svg" -o "code_logo.png"
 
   for file in "${VSCODE_PREFIX}"vscode/resources/darwin/*; do
     if [[ -f "${file}" ]]; then
-      name=$(basename "${file}" '.icns')
+      name="${file%.icns}"
 
       if [[ "${name}" != 'code' ]] && [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/darwin/${name}.icns" ]]; then
         icns2png -x -s 512x512 "${file}" -o .
@@ -123,13 +125,14 @@ build_windows_type() {
 }
 
 build_windows_types() { # {{{
+  local file name
   mkdir -p "${SRC_PREFIX}src/${QUALITY}/resources/win32"
 
   rsvg-convert -b "#F5F6F7" -w 64 -h 64 "icons/${QUALITY}/codium_cnl.svg" -o "code_logo.png"
 
   for file in "${VSCODE_PREFIX}"vscode/resources/win32/*.ico; do
     if [[ -f "${file}" ]]; then
-      name=$(basename "${file}" '.ico')
+      name="${file%.ico}"
 
       if [[ "${name}" != 'code' ]] && [[ ! -f "${SRC_PREFIX}src/${QUALITY}/resources/win32/${name}.ico" ]]; then
         icotool -x -w 256 "${file}"

--- a/prepare_assets.sh
+++ b/prepare_assets.sh
@@ -173,12 +173,15 @@ if [[ "${SHOULD_BUILD_REH}" != "no" ]]; then
   cd ..
 fi
 
+get_sum() {
+  local file
+  for file in *; do
+    if [[ -f "${file}" ]]; then
+      sum_file "${file}"
+    fi
+  done
+}
+
 cd assets
-
-for FILE in *; do
-  if [[ -f "${FILE}" ]]; then
-    sum_file "${FILE}"
-  fi
-done
-
+get_sum
 cd ..

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -23,21 +23,19 @@ cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
 apply_patches() {
   local file
-  for file in ${1}; do
-    if [[ -f "${file}" ]]; then
-      echo applying patch: "${file}"
-      if ! git apply --ignore-whitespace "${file}"; then
-        echo failed to apply patch "${file}" >&2; exit 1
-      fi
+  while IFS= read -r file; do
+    echo applying patch: "${file}"
+    if ! git apply --ignore-whitespace "${file}"; then
+      echo failed to apply patch "${file}" >&2; exit 1
     fi
-  done
+  done < <( find "${1}" -type f -name "*.patch" )
 }
 
-apply_patches "../patches/*.patch"
-apply_patches "../patches/user/*.patch"
+apply_patches "../patches/"
+apply_patches "../patches/user/"
 
 if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
-  apply_patches "../patches/insider/*.patch"
+  apply_patches "../patches/insider/"
 fi
 
 set -x

--- a/release.sh
+++ b/release.sh
@@ -2,71 +2,81 @@
 
 set -e
 
-if [[ -z "${GITHUB_TOKEN}" ]]; then
-  echo "Will not release because no GITHUB_TOKEN defined"
-  exit
-fi
-
-REPOSITORY_OWNER="${ASSETS_REPOSITORY/\/*/}"
-REPOSITORY_NAME="${ASSETS_REPOSITORY/*\//}"
-
-npm install -g github-release-cli
-
-if [[ $( gh release view --repo "${ASSETS_REPOSITORY}" "${RELEASE_VERSION}" 2>&1 ) =~ "release not found" ]]; then
-  echo "Creating release '${RELEASE_VERSION}'"
-
-  if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
-    NOTES="update vscode to [${MS_COMMIT}](https://github.com/microsoft/vscode/tree/${MS_COMMIT})"
-    CREATE_OPTIONS=""
-  else
-    NOTES="update vscode to [${MS_TAG}](https://code.visualstudio.com/updates/v$( echo "${MS_TAG//./_}" | cut -d'_' -f 1,2 ))"
-    CREATE_OPTIONS="--generate-notes"
+create_github_release() {
+  local notes
+  if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "Will not release because no GITHUB_TOKEN defined"
+    exit
   fi
 
-  gh release create "${RELEASE_VERSION}" --repo "${ASSETS_REPOSITORY}" --title "${RELEASE_VERSION}" --notes "${NOTES}" ${CREATE_OPTIONS}
-fi
+  REPOSITORY_OWNER="${ASSETS_REPOSITORY/\/*/}"
+  REPOSITORY_NAME="${ASSETS_REPOSITORY/*\//}"
+
+  npm install -g github-release-cli
+
+  if [[ $( gh release view --repo "${ASSETS_REPOSITORY}" "${RELEASE_VERSION}" 2>&1 ) =~ "release not found" ]]; then
+    echo "Creating release '${RELEASE_VERSION}'"
+
+    if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
+      notes="update vscode to [${MS_COMMIT}](https://github.com/microsoft/vscode/tree/${MS_COMMIT})"
+      CREATE_OPTIONS=""
+    else
+      notes="update vscode to [${MS_TAG}](https://code.visualstudio.com/updates/v$( echo "${MS_TAG//./_}" | cut -d'_' -f 1,2 ))"
+      CREATE_OPTIONS="--generate-notes"
+    fi
+
+    gh release create "${RELEASE_VERSION}" --repo "${ASSETS_REPOSITORY}" --title "${RELEASE_VERSION}" --notes "${notes}" ${CREATE_OPTIONS}
+  fi
+}
+
+create_github_release
 
 cd assets
 
 set +e
 
-for FILE in *; do
-  if [[ -f "${FILE}" ]] && [[ "${FILE}" != *.sha1 ]] && [[ "${FILE}" != *.sha256 ]]; then
-    echo "::group::Uploading '${FILE}' at $( date "+%T" )"
-    gh release upload --repo "${ASSETS_REPOSITORY}" "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+upload_release_files() {
+  local file exit_status
+  for file in *; do
+    if [[ -f "${file}" ]] && [[ "${file}" != *.sha1 ]] && [[ "${file}" != *.sha256 ]]; then
+      echo "::group::Uploading '${file}' at $( date "+%T" )"
+      gh release upload --repo "${ASSETS_REPOSITORY}" "${RELEASE_VERSION}" "${file}" "${file}.sha1" "${file}.sha256"
 
-    EXIT_STATUS=$?
-    echo "exit: ${EXIT_STATUS}"
+      exit_status=$?
+      echo "exit: ${exit_status}"
 
-    if (( "${EXIT_STATUS}" )); then
-      for (( i=0; i<10; i++ )); do
-        github-release delete --owner "${REPOSITORY_OWNER}" --repo "${REPOSITORY_NAME}" --tag "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+      if (( "${exit_status}" )); then
+        for (( i=0; i<10; i++ )); do
+          github-release delete --owner "${REPOSITORY_OWNER}" --repo "${REPOSITORY_NAME}" --tag "${RELEASE_VERSION}" "${file}" "${file}.sha1" "${file}.sha256"
 
-        sleep $(( 15 * (i + 1)))
+          sleep $(( 15 * (i + 1)))
 
-        echo "RE-Uploading '${FILE}' at $( date "+%T" )"
-        gh release upload --repo "${ASSETS_REPOSITORY}" "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
+          echo "RE-Uploading '${file}' at $( date "+%T" )"
+          gh release upload --repo "${ASSETS_REPOSITORY}" "${RELEASE_VERSION}" "${file}" "${file}.sha1" "${file}.sha256"
 
-        EXIT_STATUS=$?
-        echo "exit: ${EXIT_STATUS}"
+          exit_status=$?
+          echo "exit: ${exit_status}"
 
-        if ! (( "${EXIT_STATUS}" )); then
-          break
+          if ! (( "${exit_status}" )); then
+            break
+          fi
+        done
+        echo "exit: ${exit_status}"
+
+        if (( "${exit_status}" )); then
+          echo "'${file}' hasn't been uploaded!"
+
+          github-release delete --owner "${REPOSITORY_OWNER}" --repo "${REPOSITORY_NAME}" --tag "${RELEASE_VERSION}" "${file}" "${file}.sha1" "${file}.sha256"
+
+          exit 1
         fi
-      done
-      echo "exit: ${EXIT_STATUS}"
-
-      if (( "${EXIT_STATUS}" )); then
-        echo "'${FILE}' hasn't been uploaded!"
-
-        github-release delete --owner "${REPOSITORY_OWNER}" --repo "${REPOSITORY_NAME}" --tag "${RELEASE_VERSION}" "${FILE}" "${FILE}.sha1" "${FILE}.sha256"
-
-        exit 1
       fi
-    fi
 
-    echo "::endgroup::"
-  fi
-done
+      echo "::endgroup::"
+    fi
+  done
+}
+
+upload_release_files
 
 cd ..

--- a/update_insider.sh
+++ b/update_insider.sh
@@ -2,30 +2,39 @@
 
 set -e
 
-if [[ "${SHOULD_BUILD}" != "yes" ]]; then
-  echo "Will not update version JSON because we did not build"
-  exit 0
-fi
-
-if [[ -z "${GITHUB_TOKEN}" ]]; then
-  echo "Will not update insider.json because no GITHUB_TOKEN defined"
-  exit 0
-fi
-
-jsonTmp=$( jq --arg 'tag' "${MS_TAG/\-insider/}" --arg 'commit' "${MS_COMMIT}" '. "insider.json" | .tag=$tag | .commit=$commit' )
-echo "${jsonTmp}" > "insider.json" && unset jsonTmp
-
-git config user.email "$( echo "${GITHUB_USERNAME}" | awk '{print tolower($0)}' )-ci@not-real.com"
-git config user.name "${GITHUB_USERNAME} CI"
-git add .
-
-CHANGES=$( git status --porcelain )
-
-if [[ -n "${CHANGES}" ]]; then
-  git commit -m "build(insider): update to commit ${MS_COMMIT:0:7}"
-
-  if ! git push origin insider --quiet; then
-    git pull origin insider
-    git push origin insider --quiet
+update_json() {
+  local jsonTmp
+  if [[ "${SHOULD_BUILD}" != "yes" ]]; then
+    echo "Will not update version JSON because we did not build"
+    exit 0
   fi
-fi
+
+  if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "Will not update insider.json because no GITHUB_TOKEN defined"
+    exit 0
+  fi
+
+  jsonTmp=$( jq --arg 'tag' "${MS_TAG/\-insider/}" --arg 'commit' "${MS_COMMIT}" '. "insider.json" | .tag=$tag | .commit=$commit' )
+  echo "${jsonTmp}" > "insider.json"
+
+  git config user.email "$( echo "${GITHUB_USERNAME}" | awk '{print tolower($0)}' )-ci@not-real.com"
+  git config user.name "${GITHUB_USERNAME} CI"
+  git add .
+}
+
+push_if_changes() {
+  local changes
+  changes=$( git status --porcelain )
+
+  if [[ -n "${changes}" ]]; then
+    git commit -m "build(insider): update to commit ${MS_COMMIT:0:7}"
+
+    if ! git push origin insider --quiet; then
+      git pull origin insider
+      git push origin insider --quiet
+    fi
+  fi
+}
+
+update_json
+push_if_changes

--- a/update_settings.sh
+++ b/update_settings.sh
@@ -1,18 +1,19 @@
 # shellcheck disable=SC1091,2148
 
-DEFAULT_TRUE="'default': true"
-DEFAULT_FALSE="'default': false"
-DEFAULT_ON="'default': TelemetryConfiguration.ON"
-DEFAULT_OFF="'default': TelemetryConfiguration.OFF"
-TELEMETRY_CRASH_REPORTER="'telemetry.enableCrashReporter':"
-TELEMETRY_CONFIGURATION=" TelemetryConfiguration.ON"
-NLS=workbench.settings.enableNaturalLanguageSearch
-
 # include common functions
 . ../utils.sh
 
 update_setting () {
-  local FILENAME SETTING LINE_NUM IN_SETTING FOUND DEFAULT_TRUE_TO_FALSE
+  local FILENAME SETTING LINE_NUM IN_SETTING FOUND DEFAULT_TRUE_TO_FALSE DEFAULT_TRUE DEFAULT_FALSE
+  local DEFAULT_ON DEFAULT_OFF TELEMETRY_CRASH_REPORTER TELEMETRY_CONFIGURATION NLS line
+
+  DEFAULT_TRUE="'default': true"
+  DEFAULT_FALSE="'default': false"
+  DEFAULT_ON="'default': TelemetryConfiguration.ON"
+  DEFAULT_OFF="'default': TelemetryConfiguration.OFF"
+  TELEMETRY_CRASH_REPORTER="'telemetry.enableCrashReporter':"
+  TELEMETRY_CONFIGURATION=" TelemetryConfiguration.ON"
+  NLS=workbench.settings.enableNaturalLanguageSearch
 
   FILENAME="${2}"
   # check that the file exists

--- a/update_version.sh
+++ b/update_version.sh
@@ -50,7 +50,7 @@ REPOSITORY_NAME="${VERSIONS_REPOSITORY/*\//}"
 URL_BASE="https://github.com/${ASSETS_REPOSITORY}/releases/download/${RELEASE_VERSION}"
 
 generateJson() {
-  local url name version productVersion sha1hash sha256hash timestamp
+  local url name version productVersion sha1hash sha256hash timestamp key
   JSON_DATA="{}"
 
   # generate parts
@@ -168,21 +168,26 @@ cd "${REPOSITORY_NAME}" || { echo "'${REPOSITORY_NAME}' dir not found"; exit 1; 
 git pull origin master # in case another build just pushed
 git add .
 
-CHANGES=$( git status --porcelain )
+push_if_changes() {
+  local changes
+  changes=$( git status --porcelain )
 
-if [[ -n "${CHANGES}" ]]; then
-  echo "Some changes have been found, pushing them"
+  if [[ -n "${changes}" ]]; then
+    echo "Some changes have been found, pushing them"
 
-  dateAndMonth=$( date "+%D %T" )
+    dateAndMonth=$( date "+%D %T" )
 
-  git commit -m "CI update: ${dateAndMonth} (Build ${GITHUB_RUN_NUMBER})"
+    git commit -m "CI update: ${dateAndMonth} (Build ${GITHUB_RUN_NUMBER})"
 
-  if ! git push origin master --quiet; then
-    git pull origin master
-    git push origin master --quiet
+    if ! git push origin master --quiet; then
+      git pull origin master
+      git push origin master --quiet
+    fi
+  else
+    echo "No changes"
   fi
-else
-  echo "No changes"
-fi
+}
+
+push_if_changes
 
 cd ..


### PR DESCRIPTION
I'm working on reducing global variable assignment which should reduce the overhead on your build process. A nice side-effect in this particular instance was removing some repetitive code. If you like this, I'll keep plugging away at it as I have time.

1. Created `apply_patches` function. This allows for assigning `file` locally as it's not needed after the patches are applied.
    - Note: in this case I left `${1}` unquoted so the loop will iterate over the glob ([https://www.shellcheck.net/wiki/SC2066](https://www.shellcheck.net/wiki/SC2066)).
    - Also note, I double quoted the file paths. We know there are no spaces in this file path, but it's still a good habit in case there is.
2. I removed the `setpath_json` function. The only difference in the `setpath` functions is `--arg` vs `--argjson`. I made `--argson` an argument in the applicable lines and used `--arg` as the default value. This makes no difference outside of removing repeated code, so I'm happy to revert if you don't like it.