### PR TITLE
[vscodium][linux] Fix the patch file for linux builds

### DIFF
--- a/patches/fix-build-linux.patch
+++ b/patches/fix-build-linux.patch
@@ -22,7 +22,7 @@ index 0ea6699..c4524de 100644
  // are valid, are in dep-lists.ts
 -const FAIL_BUILD_FOR_NEW_DEPENDENCIES = true;
 +const FAIL_BUILD_FOR_NEW_DEPENDENCIES = false;
- // Based on https://source.chromium.org/chromium/chromium/src/+/refs/tags/108.0.5359.215:chrome/installer/linux/BUILD.gn;l=64-80
+ // Based on https://source.chromium.org/chromium/chromium/src/+/refs/tags/114.0.5735.199:chrome/installer/linux/BUILD.gn;l=64-80
 diff --git a/build/linux/dependencies-generator.ts b/build/linux/dependencies-generator.ts
 index c0d8112..3bb0366 100644
 --- a/build/linux/dependencies-generator.ts


### PR DESCRIPTION
The URL was updated on the vscode repo, but not updated for the patch. Fixing it on this commit.

The code which changed is here: https://github.com/microsoft/vscode/blob/main/build/linux/dependencies-generator.js#L24C1-L25C1