### PR TITLE
feat: prepare for 1.85

### DIFF
--- a/.github/workflows/insider-macos.yml
+++ b/.github/workflows/insider-macos.yml
@@ -51,7 +51,7 @@ jobs:
           ref: ${{ env.GITHUB_BRANCH }}
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.17'
 

--- a/.github/workflows/insider-spearhead.yml
+++ b/.github/workflows/insider-spearhead.yml
@@ -23,7 +23,7 @@ jobs:
           ref: insider
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 

--- a/.github/workflows/insider-windows.yml
+++ b/.github/workflows/insider-windows.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ env.GITHUB_BRANCH }}
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.17'
 

--- a/.github/workflows/insider-windows.yml
+++ b/.github/workflows/insider-windows.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Clone VSCode repo
         env:

--- a/.github/workflows/insider-windows.yml
+++ b/.github/workflows/insider-windows.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         vscode_arch:
           - x64
-          - ia32
+          # - ia32
           - arm64
     outputs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/stable-macos.yml
+++ b/.github/workflows/stable-macos.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.17'
 

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.17'
 

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Clone VSCode repo
         run: ./get_repo.sh

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         vscode_arch:
           - x64
-          - ia32
+          # - ia32
           - arm64
     outputs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/insider.json
+++ b/insider.json
@@ -1,4 +1,4 @@
 {
   "tag": "1.84.0",
-  "commit": "55d1cfea45b665bb54e46d11bd3ccddf9e66108b"
+  "commit": "60182c7e1a666961ded4d0319c154f52d85daf30"
 }

--- a/patches/brand.patch
+++ b/patches/brand.patch
@@ -73,7 +73,7 @@ index 8bb2a46..7cee594 100644
 +const bumpEngineForImplicitActivationEvents = l10n.t("This activation event can be removed for extensions targeting engine version ^1.75 as VSCodium will generate these automatically from your package.json contribution declarations.");
  const starActivation = l10n.t("Using '*' activation is usually a bad idea as it impacts performance.");
 diff --git a/extensions/git/package.nls.json b/extensions/git/package.nls.json
-index 8081c90..82b849f 100644
+index 20a807b..f7e8178 100644
 --- a/extensions/git/package.nls.json
 +++ b/extensions/git/package.nls.json
 @@ -205,3 +205,3 @@
@@ -81,29 +81,29 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -232,4 +232,4 @@
+@@ -233,4 +233,4 @@
  	"config.showCommitInput": "Controls whether to show the commit input in the Git source control panel.",
 -	"config.terminalAuthentication": "Controls whether to enable VS Code to be the authentication handler for Git processes spawned in the Integrated Terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
 -	"config.terminalGitEditor": "Controls whether to enable VS Code to be the Git editor for Git processes spawned in the integrated terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
 +	"config.terminalAuthentication": "Controls whether to enable VSCodium to be the authentication handler for Git processes spawned in the Integrated Terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
 +	"config.terminalGitEditor": "Controls whether to enable VSCodium to be the Git editor for Git processes spawned in the integrated terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
  	"config.timeline.showAuthor": "Controls whether to show the commit author in the Timeline view.",
-@@ -284,3 +284,3 @@
+@@ -285,3 +285,3 @@
  			"{Locked='](command:workbench.action.reloadWindow'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -292,3 +292,3 @@
+@@ -293,3 +293,3 @@
  			"{Locked='](command:workbench.action.reloadWindow'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -300,3 +300,3 @@
+@@ -301,3 +301,3 @@
  			"{Locked='](command:workbench.action.reloadWindow'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -306,6 +306,6 @@
+@@ -307,6 +307,6 @@
  	"view.workbench.scm.disabled": {
 -		"message": "If you would like to use Git features, please enable Git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D).\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "If you would like to use Git features, please enable Git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D).\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -112,7 +112,7 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -314,6 +314,6 @@
+@@ -315,6 +315,6 @@
  	"view.workbench.scm.empty": {
 -		"message": "In order to use Git features, you can open a folder containing a Git repository or clone from a URL.\n[Open Folder](command:vscode.openFolder)\n[Clone Repository](command:git.clone)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "In order to use Git features, you can open a folder containing a Git repository or clone from a URL.\n[Open Folder](command:vscode.openFolder)\n[Clone Repository](command:git.clone)\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -121,7 +121,7 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -322,6 +322,6 @@
+@@ -323,6 +323,6 @@
  	"view.workbench.scm.folder": {
 -		"message": "The folder currently open doesn't have a Git repository. You can initialize a repository which will enable source control features powered by Git.\n[Initialize Repository](command:git.init?%5Btrue%5D)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "The folder currently open doesn't have a Git repository. You can initialize a repository which will enable source control features powered by Git.\n[Initialize Repository](command:git.init?%5Btrue%5D)\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -130,7 +130,7 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -330,6 +330,6 @@
+@@ -331,6 +331,6 @@
  	"view.workbench.scm.workspace": {
 -		"message": "The workspace currently open doesn't have any folders containing Git repositories. You can initialize a repository on a folder which will enable source control features powered by Git.\n[Initialize Repository](command:git.init)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "The workspace currently open doesn't have any folders containing Git repositories. You can initialize a repository on a folder which will enable source control features powered by Git.\n[Initialize Repository](command:git.init)\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -139,7 +139,7 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -338,6 +338,6 @@
+@@ -339,6 +339,6 @@
  	"view.workbench.scm.emptyWorkspace": {
 -		"message": "The workspace currently open doesn't have any folders containing Git repositories.\n[Add Folder to Workspace](command:workbench.action.addRootFolder)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "The workspace currently open doesn't have any folders containing Git repositories.\n[Add Folder to Workspace](command:workbench.action.addRootFolder)\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -148,27 +148,27 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -356,3 +356,3 @@
+@@ -357,3 +357,3 @@
  			"{Locked='](command:workbench.action.openSettings?%5B%22git.openRepositoryInParentFolders%22%5D'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -365,3 +365,3 @@
+@@ -366,3 +366,3 @@
  			"{Locked='](command:workbench.action.openSettings?%5B%22git.openRepositoryInParentFolders%22%5D'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -373,3 +373,3 @@
+@@ -374,3 +374,3 @@
  			"{Locked='](command:git.manageUnsafeRepositories'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -381,3 +381,3 @@
+@@ -382,3 +382,3 @@
  			"{Locked='](command:git.manageUnsafeRepositories'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -386,6 +386,6 @@
+@@ -387,6 +387,6 @@
  	"view.workbench.scm.closedRepository": {
 -		"message": "A Git repository was found that was previously closed.\n[Reopen Closed Repository](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "A Git repository was found that was previously closed.\n[Reopen Closed Repository](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -177,7 +177,7 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -394,6 +394,6 @@
+@@ -395,6 +395,6 @@
  	"view.workbench.scm.closedRepositories": {
 -		"message": "Git repositories were found that were previously closed.\n[Reopen Closed Repositories](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).",
 +		"message": "Git repositories were found that were previously closed.\n[Reopen Closed Repositories](command:git.reopenClosedRepositories)\nTo learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm).",
@@ -186,12 +186,12 @@ index 8081c90..82b849f 100644
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -405,3 +405,3 @@
+@@ -406,3 +406,3 @@
  			"{Locked='](command:git.clone'}",
 -			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VS Code",
 +			"Do not translate the 'command:*' part inside of the '(..)'. It is an internal command syntax for VSCodium",
  			"Please make sure there is no space between the right bracket and left parenthesis:  ]( this is an internal syntax for links"
-@@ -409,3 +409,3 @@
+@@ -410,3 +410,3 @@
  	},
 -	"view.workbench.learnMore": "To learn more about how to use Git and source control in VS Code [read our docs](https://aka.ms/vscode-scm)."
 +	"view.workbench.learnMore": "To learn more about how to use Git and source control in VSCodium [read our docs](https://aka.ms/vscode-scm)."
@@ -273,7 +273,7 @@ index e82030e..1a634bd 100644
 +	"displayName": "Jake support for VSCodium",
  	"jake.taskDefinition.type.description": "The Jake task to customize.",
 diff --git a/extensions/json-language-features/package.nls.json b/extensions/json-language-features/package.nls.json
-index 2586bc6..f2a03f5 100644
+index af6c9d8..7057b54 100644
 --- a/extensions/json-language-features/package.nls.json
 +++ b/extensions/json-language-features/package.nls.json
 @@ -11,3 +11,3 @@
@@ -354,25 +354,27 @@ index f63b127..799111f 100644
 +					"comment": "The simpler (?<=\\bProcess\\.|\\bCommandLine\\.) breaks VSCodium / Atom, see https://github.com/textmate/swift.tmbundle/issues/29",
  					"match": "(?<=^Process\\.|\\WProcess\\.|^CommandLine\\.|\\WCommandLine\\.)(arguments|argc|unsafeArgv)",
 diff --git a/extensions/typescript-language-features/package.nls.json b/extensions/typescript-language-features/package.nls.json
-index f31c5fa..b53164e 100644
+index 4ae4c9a..d722b4f 100644
 --- a/extensions/typescript-language-features/package.nls.json
 +++ b/extensions/typescript-language-features/package.nls.json
-@@ -83,3 +83,3 @@
+@@ -83,4 +83,4 @@
  	"configuration.tsserver.experimental.enableProjectDiagnostics": "(Experimental) Enables project wide error reporting.",
 -	"typescript.locale": "Sets the locale used to report JavaScript and TypeScript errors. Defaults to use VS Code's locale.",
+-	"typescript.locale.auto": "Use VS Code's configured display language",
 +	"typescript.locale": "Sets the locale used to report JavaScript and TypeScript errors. Defaults to use VSCodium's locale.",
++	"typescript.locale.auto": "Use VSCodium's configured display language",
  	"configuration.implicitProjectConfig.module": "Sets the module system for the program. See more: https://www.typescriptlang.org/tsconfig#module.",
-@@ -165,3 +165,3 @@
+@@ -166,3 +166,3 @@
  	"typescript.workspaceSymbols.excludeLibrarySymbols": "Exclude symbols that come from library files in Go to Symbol in Workspace results. Requires using TypeScript 5.3+ in the workspace.",
 -	"typescript.updateImportsOnFileMove.enabled": "Enable/disable automatic updating of import paths when you rename or move a file in VS Code.",
 +	"typescript.updateImportsOnFileMove.enabled": "Enable/disable automatic updating of import paths when you rename or move a file in VSCodium.",
  	"typescript.updateImportsOnFileMove.enabled.prompt": "Prompt on each rename.",
-@@ -171,3 +171,3 @@
+@@ -172,3 +172,3 @@
  	"typescript.suggest.enabled": "Enabled/disable autocomplete suggestions.",
 -	"configuration.surveys.enabled": "Enabled/disable occasional surveys that help us improve VS Code's JavaScript and TypeScript support.",
 +	"configuration.surveys.enabled": "Enabled/disable occasional surveys that help us improve VSCodium's JavaScript and TypeScript support.",
  	"configuration.suggest.completeJSDocs": "Enable/disable suggestion to complete JSDoc comments.",
-@@ -223,5 +223,5 @@
+@@ -224,5 +224,5 @@
  	"configuration.suggest.objectLiteralMethodSnippets.enabled": "Enable/disable snippet completions for methods in object literals.",
 -	"configuration.tsserver.web.projectWideIntellisense.enabled": "Enable/disable project-wide IntelliSense on web. Requires that VS Code is running in a trusted context.",
 +	"configuration.tsserver.web.projectWideIntellisense.enabled": "Enable/disable project-wide IntelliSense on web. Requires that VSCodium is running in a trusted context.",
@@ -380,7 +382,7 @@ index f31c5fa..b53164e 100644
 -	"configuration.tsserver.nodePath": "Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VS Code to detect a Node installation.",
 +	"configuration.tsserver.nodePath": "Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VSCodium to detect a Node installation.",
  	"configuration.experimental.tsserver.web.typeAcquisition.enabled": "Enable/disable package acquisition on the web.",
-@@ -236,6 +236,6 @@
+@@ -237,6 +237,6 @@
  	"walkthroughs.nodejsWelcome.debugJsFile.title": "Run and Debug your JavaScript",
 -	"walkthroughs.nodejsWelcome.debugJsFile.description": "Once you've installed Node.js, you can run JavaScript programs at a terminal by entering ``node your-file-name.js``\nAnother easy way to run Node.js programs is by using VS Code's debugger which lets you run your code, pause at different points, and help you understand what's going on step-by-step.\n[Start Debugging](command:javascript-walkthrough.commands.debugJsFile)",
 +	"walkthroughs.nodejsWelcome.debugJsFile.description": "Once you've installed Node.js, you can run JavaScript programs at a terminal by entering ``node your-file-name.js``\nAnother easy way to run Node.js programs is by using VSCodium's debugger which lets you run your code, pause at different points, and help you understand what's going on step-by-step.\n[Start Debugging](command:javascript-walkthrough.commands.debugJsFile)",
@@ -408,7 +410,7 @@ index 239519e..a308077 100644
 +		vscode.window.showErrorMessage(vscode.l10n.t("VSCodium\'s tsserver was deleted by another application such as a misbehaving virus detection tool. Please reinstall VSCodium."));
  		throw new Error('Could not find bundled tsserver.js');
 diff --git a/extensions/typescript-language-features/src/tsconfig.ts b/extensions/typescript-language-features/src/tsconfig.ts
-index f5f91b2..f564ebe 100644
+index 196cf18..db942c9 100644
 --- a/extensions/typescript-language-features/src/tsconfig.ts
 +++ b/extensions/typescript-language-features/src/tsconfig.ts
 @@ -151,3 +151,3 @@ export async function openProjectConfigForFile(
@@ -436,7 +438,7 @@ index a389142..ebae0c2 100644
 +							vscode.l10n.t("The JS/TS language service crashed.\nThis may be caused by a plugin contributed by one of these extensions: {0}.\nPlease try disabling these extensions before filing an issue against VSCodium.", pluginExtensionList));
  					} else {
 diff --git a/extensions/vscode-api-tests/package.json b/extensions/vscode-api-tests/package.json
-index 65fa420..ce8310f 100644
+index beb65ff..7163741 100644
 --- a/extensions/vscode-api-tests/package.json
 +++ b/extensions/vscode-api-tests/package.json
 @@ -2,3 +2,3 @@
@@ -514,19 +516,19 @@ index fa001b5..13abac2 100644
 +			throw Error(`Failed to download and unzip VSCodium ${quality} - ${commit}`);
  		}
 diff --git a/src/vs/code/electron-main/app.ts b/src/vs/code/electron-main/app.ts
-index 642abb8..f4231e0 100644
+index 5eef587..da0ba80 100644
 --- a/src/vs/code/electron-main/app.ts
 +++ b/src/vs/code/electron-main/app.ts
-@@ -552,3 +552,3 @@ export class CodeApplication extends Disposable {
+@@ -544,3 +544,3 @@ export class CodeApplication extends Disposable {
  	async startup(): Promise<void> {
 -		this.logService.debug('Starting VS Code');
 +		this.logService.debug('Starting VSCodium');
  		this.logService.debug(`from: ${this.environmentMainService.appRoot}`);
 diff --git a/src/vs/code/electron-sandbox/issue/issueReporterService.ts b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
-index ebb776a..f686838 100644
+index afb7a65..88ed468 100644
 --- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
 +++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
-@@ -724,3 +724,3 @@ export class IssueReporter extends Disposable {
+@@ -779,3 +779,3 @@ export class IssueReporter extends Disposable {
  			hide(descriptionTextArea);
 -			reset(descriptionTitle, localize('handlesIssuesElsewhere', "This extension handles issues outside of VS Code"));
 +			reset(descriptionTitle, localize('handlesIssuesElsewhere', "This extension handles issues outside of VSCodium"));
@@ -550,7 +552,7 @@ index 296245b..cf03674 100644
 +export const ProductQualityContext = new RawContextKey<string>('productQualityType', '', localize('productQualityType', "Quality type of VSCodium"));
  
 diff --git a/src/vs/platform/extensionManagement/node/extensionManagementService.ts b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
-index f8e8204..1b0de85 100644
+index 2fb974e..86895d5 100644
 --- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
 +++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
 @@ -151,3 +151,3 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
@@ -558,17 +560,17 @@ index f8e8204..1b0de85 100644
 -				throw new Error(nls.localize('incompatible', "Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.", extensionId, this.productService.version));
 +				throw new Error(nls.localize('incompatible', "Unable to install extension '{0}' as it is not compatible with VSCodium '{1}'.", extensionId, this.productService.version));
  			}
-@@ -221,3 +221,3 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
+@@ -227,3 +227,3 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
  		} catch (e) {
 -			throw new Error(nls.localize('removeError', "Error while removing the extension: {0}. Please Quit and Start VS Code before trying again.", toErrorMessage(e)));
 +			throw new Error(nls.localize('removeError', "Error while removing the extension: {0}. Please Quit and Start VSCodium before trying again.", toErrorMessage(e)));
  		}
-@@ -960,3 +960,3 @@ class InstallVSIXTask extends InstallExtensionTask {
+@@ -966,3 +966,3 @@ class InstallVSIXTask extends InstallExtensionTask {
  				} catch (e) {
 -					throw new Error(nls.localize('restartCode', "Please restart VS Code before reinstalling {0}.", this.manifest.displayName || this.manifest.name));
 +					throw new Error(nls.localize('restartCode', "Please restart VSCodium before reinstalling {0}.", this.manifest.displayName || this.manifest.name));
  				}
-@@ -973,3 +973,3 @@ class InstallVSIXTask extends InstallExtensionTask {
+@@ -979,3 +979,3 @@ class InstallVSIXTask extends InstallExtensionTask {
  				} catch (e) {
 -					throw new Error(nls.localize('restartCode', "Please restart VS Code before reinstalling {0}.", this.manifest.displayName || this.manifest.name));
 +					throw new Error(nls.localize('restartCode', "Please restart VSCodium before reinstalling {0}.", this.manifest.displayName || this.manifest.name));
@@ -630,7 +632,7 @@ index 10e1acb..bf89402 100644
 +	console.error('Unable to connect to VSCodium server: ' + message);
  	console.error(err);
 diff --git a/src/vs/workbench/api/browser/viewsExtensionPoint.ts b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
-index 23d64b2..e0d0014 100644
+index c17a247..e7f7417 100644
 --- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
 +++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
 @@ -49,3 +49,3 @@ const viewsContainerSchema: IJSONSchema = {
@@ -639,13 +641,13 @@ index 23d64b2..e0d0014 100644
 +			description: localize({ key: 'vscode.extension.contributes.views.containers.id', comment: ['Contribution refers to those that an extension contributes to VSCodium through an extension/contribution point. '] }, "Unique id used to identify the container in which views can be contributed using 'views' contribution point"),
  			type: 'string',
 diff --git a/src/vs/workbench/api/common/extHostApiCommands.ts b/src/vs/workbench/api/common/extHostApiCommands.ts
-index f4f7c8e..d62d10f 100644
+index e79c39c..cc650b9 100644
 --- a/src/vs/workbench/api/common/extHostApiCommands.ts
 +++ b/src/vs/workbench/api/common/extHostApiCommands.ts
 @@ -413,3 +413,3 @@ const newCommands: ApiCommand[] = [
  			ApiCommandArgument.Uri.with('resource', 'Resource to open'),
--			ApiCommandArgument.String.with('viewId', 'Custom editor view id or \'default\' to use VS Code\'s default editor'),
-+			ApiCommandArgument.String.with('viewId', 'Custom editor view id or \'default\' to use VSCodium\'s default editor'),
+-			ApiCommandArgument.String.with('viewId', 'Custom editor view id. This should be the viewType string for custom editors or the notebookType string for notebooks. Use \'default\' to use VS Code\'s default text editor'),
++			ApiCommandArgument.String.with('viewId', 'Custom editor view id. This should be the viewType string for custom editors or the notebookType string for notebooks. Use \'default\' to use VSCodium\'s default text editor'),
  			new ApiCommandArgument<vscode.ViewColumn | typeConverters.TextEditorOpenOptions | undefined, [vscode.ViewColumn?, ITextEditorOptions?] | undefined>('columnOrOptions', 'Either the column in which to open or editor options, see vscode.TextDocumentShowOptions',
 diff --git a/src/vs/workbench/api/common/extHostCommands.ts b/src/vs/workbench/api/common/extHostCommands.ts
 index 7b88374..b85d8ab 100644
@@ -666,10 +668,10 @@ index 7de8e1f..61999c1 100644
 +	test('Opening a notebook results in VSCodium firing the event onDidChangeActiveNotebookEditor twice #118470', function () {
  		let count = 0;
 diff --git a/src/vs/workbench/browser/workbench.contribution.ts b/src/vs/workbench/browser/workbench.contribution.ts
-index 5e867cc..fa55ca4 100644
+index 8e1e052..4274c1e 100644
 --- a/src/vs/workbench/browser/workbench.contribution.ts
 +++ b/src/vs/workbench/browser/workbench.contribution.ts
-@@ -578,3 +578,3 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
+@@ -590,3 +590,3 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
  		localize('profileName', "`${profileName}`: name of the profile in which the workspace is opened (e.g. Data Science (Profile)). Ignored if default profile is used."),
 -		localize('appName', "`${appName}`: e.g. VS Code."),
 +		localize('appName', "`${appName}`: e.g. VSCodium."),
@@ -684,7 +686,7 @@ index 55314e5..69f4771 100644
 +						description: nls.localize('debugServer', "For debug extension development only: if a port is specified VSCodium tries to connect to a debug adapter running in server mode"),
  						default: 4711
 diff --git a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
-index 0abbb01..cd386ba 100644
+index 8293c36..ac00710 100644
 --- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
 +++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
 @@ -587,3 +587,3 @@ export class ExtensionEditor extends EditorPane {
@@ -693,7 +695,7 @@ index 0abbb01..cd386ba 100644
 +			template.navbar.push(ExtensionEditorTab.Contributions, localize('contributions', "Feature Contributions"), localize('contributionstooltip', "Lists contributions to VSCodium by this extension"));
  		}
 diff --git a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
-index 77e04f4..5c3fc65 100644
+index 3b7f3a6..8576c60 100644
 --- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
 +++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
 @@ -298,3 +298,3 @@ CommandsRegistry.registerCommand({
@@ -716,13 +718,13 @@ index 77e04f4..5c3fc65 100644
 -							'description': localize('workbench.extensions.installExtension.option.donotSync', "When enabled, VS Code do not sync this extension when Settings Sync is on."),
 +							'description': localize('workbench.extensions.installExtension.option.donotSync', "When enabled, VSCodium do not sync this extension when Settings Sync is on."),
  							default: false
-@@ -825,3 +825,3 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
+@@ -828,3 +828,3 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
  							const requireReload = !(extension.local && extensionService.canAddExtension(toExtensionDescription(extension.local)));
 -							const message = requireReload ? localize('InstallVSIXAction.successReload', "Completed installing {0} extension from VSIX. Please reload Visual Studio Code to enable it.", extension.displayName || extension.name)
 +							const message = requireReload ? localize('InstallVSIXAction.successReload', "Completed installing {0} extension from VSIX. Please reload VSCodium to enable it.", extension.displayName || extension.name)
  								: localize('InstallVSIXAction.success', "Completed installing {0} extension from VSIX.", extension.displayName || extension.name);
 diff --git a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
-index d426590..d02d85e 100644
+index 37438e0..a9f754d 100644
 --- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
 +++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
 @@ -103,3 +103,3 @@ export class PromptExtensionInstallFailureAction extends Action {
@@ -740,23 +742,23 @@ index d426590..d02d85e 100644
 -			alert(localize('uninstallExtensionComplete', "Please reload Visual Studio Code to complete the uninstallation of the extension {0}.", this.extension!.displayName));
 +			alert(localize('uninstallExtensionComplete', "Please reload VSCodium to complete the uninstallation of the extension {0}.", this.extension!.displayName));
  		});
-@@ -2219,3 +2219,3 @@ export class ExtensionStatusAction extends ExtensionAction {
+@@ -2220,3 +2220,3 @@ export class ExtensionStatusAction extends ExtensionAction {
  				const link = `[${localize('settings', "settings")}](${URI.parse(`command:workbench.action.openSettings?${encodeURIComponent(JSON.stringify([this.extension.deprecationInfo.settings.map(setting => `@id:${setting}`).join(' ')]))}`)})`;
 -				this.updateStatus({ icon: warningIcon, message: new MarkdownString(localize('deprecated with alternate settings tooltip', "This extension is deprecated as this functionality is now built-in to VS Code. Configure these {0} to use this functionality.", link)) }, true);
 +				this.updateStatus({ icon: warningIcon, message: new MarkdownString(localize('deprecated with alternate settings tooltip', "This extension is deprecated as this functionality is now built-in to VSCodium. Configure these {0} to use this functionality.", link)) }, true);
  			} else {
-@@ -2243,3 +2243,3 @@ export class ExtensionStatusAction extends ExtensionAction {
+@@ -2244,3 +2244,3 @@ export class ExtensionStatusAction extends ExtensionAction {
  			if (this.extensionManagementServerService.webExtensionManagementServer) {
 -				const productName = localize('VS Code for Web', "{0} for the Web", this.productService.nameLong);
 +				const productName = localize('VSCodium for Web', "{0} for the Web", this.productService.nameLong);
  				const message = new MarkdownString(`${localize('not web tooltip', "The '{0}' extension is not available in {1}.", this.extension.displayName || this.extension.identifier.id, productName)} [${localize('learn why', "Learn Why")}](https://aka.ms/vscode-web-extensions-guide)`);
-@@ -2505,3 +2505,3 @@ export class ReinstallAction extends Action {
+@@ -2506,3 +2506,3 @@ export class ReinstallAction extends Action {
  						const requireReload = !(extension.local && this.extensionService.canAddExtension(toExtensionDescription(extension.local)));
 -						const message = requireReload ? localize('ReinstallAction.successReload', "Please reload Visual Studio Code to complete reinstalling the extension {0}.", extension.identifier.id)
 +						const message = requireReload ? localize('ReinstallAction.successReload', "Please reload VSCodium to complete reinstalling the extension {0}.", extension.identifier.id)
  							: localize('ReinstallAction.success', "Reinstalling the extension {0} is completed.", extension.identifier.id);
 diff --git a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
-index 1546965..0732850 100644
+index 3bb04e4..f0621cb 100644
 --- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
 +++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
 @@ -344,3 +344,3 @@ export class Extension implements IExtension {
@@ -934,10 +936,10 @@ index 34fb9cc..965008e 100644
 +							message: nls.localize('TaskSystem.noProcess', 'The launched task doesn\'t exist anymore. If the task spawned background processes exiting VSCodium might result in orphaned processes. To avoid this start the last background process with a wait flag.'),
  							primaryButton: nls.localize({ key: 'TaskSystem.exitAnyways', comment: ['&& denotes a mnemonic'] }, "&&Exit Anyways"),
 diff --git a/src/vs/workbench/contrib/terminal/browser/terminalView.ts b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
-index 7d559ec..70524ca 100644
+index 2c775e3..f8cad59 100644
 --- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
 +++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
-@@ -197,3 +197,3 @@ export class TerminalViewPane extends ViewPane {
+@@ -194,3 +194,3 @@ export class TerminalViewPane extends ViewPane {
  					}];
 -					this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. Be sure to restart VS Code if this is a newly installed font."), choices);
 +					this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. Be sure to restart VSCodium if this is a newly installed font."), choices);
@@ -1006,17 +1008,17 @@ index 0902210..e403bb5 100644
 +				localize({ key: 'newThemeNotification', comment: ['{0} is the name of the new default theme'] }, "VSCodium now ships with a new default theme '{0}'. Do you want to give it a try?", theme.label),
  				choices,
 diff --git a/src/vs/workbench/contrib/update/browser/update.ts b/src/vs/workbench/contrib/update/browser/update.ts
-index bfba80a..9bf3b7b 100644
+index b0ada2a..b922fc7 100644
 --- a/src/vs/workbench/contrib/update/browser/update.ts
 +++ b/src/vs/workbench/contrib/update/browser/update.ts
-@@ -559,4 +559,4 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
+@@ -555,4 +555,4 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
  							detail: newQuality === 'insider' ?
 -								nls.localize('relaunchDetailInsiders', "Press the reload button to switch to the Insiders version of VS Code.") :
 -								nls.localize('relaunchDetailStable', "Press the reload button to switch to the Stable version of VS Code."),
 +								nls.localize('relaunchDetailInsiders', "Press the reload button to switch to the Insiders version of VSCodium.") :
 +								nls.localize('relaunchDetailStable', "Press the reload button to switch to the Stable version of VSCodium."),
  							primaryButton: nls.localize({ key: 'reload', comment: ['&& denotes a mnemonic'] }, "&&Reload")
-@@ -595,3 +595,3 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
+@@ -591,3 +591,3 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
  						message: nls.localize('selectSyncService.message', "Choose the settings sync service to use after changing the version"),
 -						detail: nls.localize('selectSyncService.detail', "The Insiders version of VS Code will synchronize your settings, keybindings, extensions, snippets and UI State using separate insiders settings sync service by default."),
 +						detail: nls.localize('selectSyncService.detail', "The Insiders version of VSCodium will synchronize your settings, keybindings, extensions, snippets and UI State using separate insiders settings sync service by default."),
@@ -1054,7 +1056,7 @@ index 9141402..b1aa321 100644
 +											description: localize('walkthroughs.steps.completionEvents.onCommand', 'Check off step when a given command is executed anywhere in VSCodium.'),
  											body: 'onCommand:${1:commandId}'
 diff --git a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
-index d7824eb..5e6377e 100644
+index 69520a4..1755696 100644
 --- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
 +++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
 @@ -173,4 +173,4 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
@@ -1064,10 +1066,12 @@ index d7824eb..5e6377e 100644
 +		title: localize('gettingStarted.setup.title', "Get Started with VSCodium"),
 +		description: localize('gettingStarted.setup.description', "Discover the best customizations to make VSCodium yours."),
  		isFeatured: true,
-@@ -195,3 +195,3 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
- 					title: localize('gettingStarted.settingsSync.title', "Sync to and from other devices"),
--					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VS Code customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Enable Settings Sync"), 'command:workbench.userDataSync.actions.turnOn')),
-+					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VSCodium customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Enable Settings Sync"), 'command:workbench.userDataSync.actions.turnOn')),
+@@ -184,4 +184,4 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
+ 					id: 'settingsSync',
+-					title: localize('gettingStarted.settingsSync.title', "Personalize your VS Code"),
+-					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VS Code customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Backup and Sync Settings"), 'command:workbench.userDataSync.actions.turnOn')),
++					title: localize('gettingStarted.settingsSync.title', "Personalize your VSCodium"),
++					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VSCodium customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Backup and Sync Settings"), 'command:workbench.userDataSync.actions.turnOn')),
  					when: 'syncStatus != uninitialized',
 @@ -205,3 +205,3 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
  					title: localize('gettingStarted.commandPalette.title', "One shortcut to access everything"),
@@ -1100,10 +1104,12 @@ index d7824eb..5e6377e 100644
 +		title: localize('gettingStarted.setupWeb.title', "Get Started with VSCodium for the Web"),
 +		description: localize('gettingStarted.setupWeb.description', "Discover the best customizations to make VSCodium for the Web yours."),
  		isFeatured: true,
-@@ -281,3 +281,3 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
- 					title: localize('gettingStarted.settingsSync.title', "Sync to and from other devices"),
--					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VS Code customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Enable Settings Sync"), 'command:workbench.userDataSync.actions.turnOn')),
-+					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VSCodium customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Enable Settings Sync"), 'command:workbench.userDataSync.actions.turnOn')),
+@@ -270,4 +270,4 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
+ 					id: 'settingsSyncWeb',
+-					title: localize('gettingStarted.settingsSync.title', "Personalize your VS Code"),
+-					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VS Code customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Backup and Sync Settings"), 'command:workbench.userDataSync.actions.turnOn')),
++					title: localize('gettingStarted.settingsSync.title', "Personalize your VSCodium"),
++					description: localize('gettingStarted.settingsSync.description.interpolated', "Keep your essential VSCodium customizations backed up and updated across all your devices.\n{0}", Button(localize('enableSync', "Backup and Sync Settings"), 'command:workbench.userDataSync.actions.turnOn')),
  					when: 'syncStatus != uninitialized',
 @@ -291,3 +291,3 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
  					title: localize('gettingStarted.commandPalette.title', "One shortcut to access everything"),
@@ -1202,15 +1208,15 @@ index 864a19e..84db739 100644
 +				markdownDescription: localize('workspace.trust.emptyWindow.description', "Controls whether or not the empty window is trusted by default within VSCodium. When used with `#{0}#`, you can enable the full functionality of VSCodium without prompting in an empty window.", WORKSPACE_TRUST_UNTRUSTED_FILES),
  				tags: [WORKSPACE_TRUST_SETTING_TAG],
 diff --git a/src/vs/workbench/electron-sandbox/desktop.contribution.ts b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
-index f904efa..dca7363 100644
+index 829ef06..38e61bb 100644
 --- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
 +++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
-@@ -362,3 +362,3 @@ import { applicationConfigurationNodeBase, securityConfigurationNodeBase } from
+@@ -367,3 +367,3 @@ import product from 'vs/platform/product/common/product';
  				type: 'boolean',
 -				description: localize('argv.disableChromiumSandbox', "Disables the Chromium sandbox. This is useful when running VS Code as elevated on Linux and running under Applocker on Windows.")
 +				description: localize('argv.disableChromiumSandbox', "Disables the Chromium sandbox. This is useful when running VSCodium as elevated on Linux and running under Applocker on Windows.")
  			},
-@@ -366,3 +366,3 @@ import { applicationConfigurationNodeBase, securityConfigurationNodeBase } from
+@@ -371,3 +371,3 @@ import product from 'vs/platform/product/common/product';
  				type: 'boolean',
 -				description: localize('argv.useInMemorySecretStorage', "Ensures that an in-memory store will be used for secret storage instead of using the OS's credential store. This is often used when running VS Code extension tests or when you're experiencing difficulties with the credential store.")
 +				description: localize('argv.useInMemorySecretStorage', "Ensures that an in-memory store will be used for secret storage instead of using the OS's credential store. This is often used when running VSCodium extension tests or when you're experiencing difficulties with the credential store.")

--- a/patches/fix-eol-banner.patch
+++ b/patches/fix-eol-banner.patch
@@ -47,16 +47,6 @@ index b120c94..1bb2b88 100644
 +	}
 +
  	toJSON(): object {
-diff --git a/src/vs/workbench/electron-sandbox/window.ts b/src/vs/workbench/electron-sandbox/window.ts
-index 1efcf6b..b52830c 100644
---- a/src/vs/workbench/electron-sandbox/window.ts
-+++ b/src/vs/workbench/electron-sandbox/window.ts
-@@ -738,3 +738,4 @@ export class NativeWindow extends Disposable {
- 				actions,
--				icon: Codicon.warning
-+				icon: Codicon.warning,
-+				neverShowAgain: { id: 'windowseol', isSecondary: true, scope: NeverShowAgainScope.APPLICATION }
- 			});
 diff --git a/src/vs/workbench/services/banner/browser/bannerService.ts b/src/vs/workbench/services/banner/browser/bannerService.ts
 index 639b1b2..70e8847 100644
 --- a/src/vs/workbench/services/banner/browser/bannerService.ts

--- a/patches/insider/disable-windows-appx.patch
+++ b/patches/insider/disable-windows-appx.patch
@@ -1,15 +1,15 @@
 diff --git a/build/gulpfile.vscode.win32.js b/build/gulpfile.vscode.win32.js
-index 0d3abda..9e5143a 100644
+index 5adfdfb..dfdb2af 100644
 --- a/build/gulpfile.vscode.win32.js
 +++ b/build/gulpfile.vscode.win32.js
-@@ -116,6 +116,6 @@ function buildWin32Setup(arch, target) {
+@@ -115,6 +115,6 @@ function buildWin32Setup(arch, target) {
  
 -		if (quality === 'insider') {
--			definitions['AppxPackage'] = `code_insiders_explorer_${arch === 'ia32' ? 'x86' : arch}.appx`;
+-			definitions['AppxPackage'] = `code_insiders_explorer_${arch}.appx`;
 -			definitions['AppxPackageFullname'] = `Microsoft.${product.win32RegValueName}_1.0.0.0_neutral__8wekyb3d8bbwe`;
 -		}
 +		// if (quality === 'insider') {
-+		// 	definitions['AppxPackage'] = `code_insiders_explorer_${arch === 'ia32' ? 'x86' : arch}.appx`;
++		// 	definitions['AppxPackage'] = `code_insiders_explorer_${arch}.appx`;
 +		// 	definitions['AppxPackageFullname'] = `Microsoft.${product.win32RegValueName}_1.0.0.0_neutral__8wekyb3d8bbwe`;
 +		// }
  

--- a/product.json
+++ b/product.json
@@ -48,8 +48,7 @@
   ],
   "extensionEnabledApiProposals": {
     "ms-vscode.vscode-selfhost-test-provider": [
-      "testObserver",
-      "testMessageContextValue"
+      "testObserver"
     ],
     "VisualStudioExptTeam.vscodeintellicode-completions": [
       "inlineCompletionsAdditions"
@@ -169,6 +168,9 @@
     "ms-vscode.lsif-browser": [
       "documentFiltersExclusive"
     ],
+    "ms-vscode.vscode-speech": [
+      "speech"
+    ],
     "GitHub.vscode-pull-request-github": [
       "contribCommentThreadAdditionalMenu",
       "tokenInformation",
@@ -199,18 +201,22 @@
       "handleIssueUri",
       "interactive",
       "interactiveUserActions",
-      "terminalContextMenu",
       "terminalDataWriteEvent",
+      "terminalExecuteCommandEvent",
       "terminalSelection",
       "terminalQuickFixProvider",
       "chatProvider",
-      "chatSlashCommands",
       "chatVariables",
       "chatAgents",
+      "chatAgents2",
+      "chatAgents2Additions",
+      "defaultChatAgent",
       "readonlyMessage",
       "mappedEditsProvider",
       "aiRelatedInformation",
-      "codeActionAI"
+      "codeActionAI",
+      "findTextInFiles",
+      "textSearchProvider"
     ],
     "GitHub.remotehub": [
       "contribRemoteHelp",


### PR DESCRIPTION
This PR prepares for 1.85.

Windows x86 (32bits) version has been removed.

On Windows, python is fixed to 3.11 due to https://github.com/nodejs/node-gyp/issues/2869