### PR TITLE
fix(windows): disable background update for MSI

### DIFF
--- a/patches/update-msi.patch
+++ b/patches/update-msi.patch
@@ -1,0 +1,9 @@
+diff --git a/src/vs/platform/update/electron-main/updateService.win32.ts b/src/vs/platform/update/electron-main/updateService.win32.ts
+index 99bf807..b5b4333 100644
+--- a/src/vs/platform/update/electron-main/updateService.win32.ts
++++ b/src/vs/platform/update/electron-main/updateService.win32.ts
+@@ -156,3 +156,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+ 					}).then(packagePath => {
+-						const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
++						const fastUpdatesEnabled = getUpdateType() == UpdateType.Setup && this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
+ 


### PR DESCRIPTION
This PR disables the background install of updates for MSI.
MSI updates can't be done in background since it will asked for the necessary permissions to copy the files in the `Program Files` folder.

#1717
