### PR TITLE
Fix quarantine CLI command to work in `troubleshooting.md`

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,5 +47,5 @@ You can right-click the App and choose `Open`.
 The following command will remove the quarantine attribute.
 
 ```
-xattr -r -d com.apple.quarantine /Applications/VSCodium.app
+xattr -d com.apple.quarantine /Applications/VSCodium.app
 ```


### PR DESCRIPTION
Fix quarantine CLI command to work

```bash
% xattr -r -d com.apple.quarantine /Applications/VSCodium.app
option -r not recognized

usage: xattr [-slz] file [file ...]
       xattr -p [-slz] attr_name file [file ...]
       xattr -w [-sz] attr_name attr_value file [file ...]
       xattr -d [-s] attr_name file [file ...]
       xattr -c [-s] file [file ...]

The first form lists the names of all xattrs on the given file(s).
The second form (-p) prints the value of the xattr attr_name.
The third form (-w) sets the value of the xattr attr_name to attr_value.
The fourth form (-d) deletes the xattr attr_name.
The fifth form (-c) deletes (clears) all xattrs.

options:
  -h: print this help
  -s: act on symbolic links themselves rather than their targets
  -l: print long format (attr_name: attr_value)
  -z: compress or decompress (if compressed) attribute value in zip format
% xattr -d com.apple.quarantine /Applications/VSCodium.app 
% 
```

The app launches after this.

I would ask the devs to consider signing the app properly. I've never had to do this before with any other open source apps on Mac.