### PR TITLE
[snap]: migrate to core22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/windows/msi/Files*.wxs
 build/windows/msi/Files*.wixobj
 stores/snapcraft/insider/*.snap
 stores/snapcraft/stable/*.snap
+stores/snapcraft/stable/codium_*.txt

--- a/stores/snapcraft/stable/snap/snapcraft.yaml
+++ b/stores/snapcraft/stable/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Code editing. Redefined.
 description: |
   Binary releases of Code without branding/telemetry/licensing
 
-base: core20
+base: core22
 grade: stable
 confinement: classic
 compression: lzo
@@ -17,48 +17,39 @@ parts:
       # Get .deb url
       wget --quiet https://api.github.com/repos/VSCodium/vscodium/releases -O latest.json
       VERSION=$( jq -r 'sort_by(.tag_name)|last.tag_name' latest.json )
-      DEB_URL=$( jq -r 'map(select(.tag_name == "'"${VERSION}"'"))|first.assets[].browser_download_url|select(endswith("'"_${SNAPCRAFT_TARGET_ARCH}.deb"'"))' latest.json )
+      DEB_URL=$( jq -r 'map(select(.tag_name == "'"${VERSION}"'"))|first.assets[].browser_download_url|select(endswith("'"_${CRAFT_TARGET_ARCH}.deb"'"))' latest.json )
       DEB_NAME=$( basename "${DEB_URL}" )
       # Downloading .deb
-      wget "${DEB_URL}" -O "${SNAPCRAFT_PART_INSTALL}/${DEB_NAME}"
+      wget "${DEB_URL}" -O "${CRAFT_PART_INSTALL}/${DEB_NAME}"
       # Unpacking .deb
-      dpkg -x "${SNAPCRAFT_PART_INSTALL}/${DEB_NAME}" "${SNAPCRAFT_PART_INSTALL}"
+      dpkg -x "${CRAFT_PART_INSTALL}/${DEB_NAME}" "${CRAFT_PART_INSTALL}"
       # Clean up
       rm -f latest.json
-      rm -f "${SNAPCRAFT_PART_INSTALL}/${DEB_NAME}"
+      rm -f "${CRAFT_PART_INSTALL}/${DEB_NAME}"
       # Set version
-      snapcraftctl set-version "${VERSION}"
+      craftctl set version=${VERSION}
       # Prepare GUI
-      mkdir -p "${SNAPCRAFT_PART_INSTALL}/meta/gui"
-      cp "${SNAPCRAFT_PART_INSTALL}/usr/share/codium/resources/app/resources/linux/code.png" "${SNAPCRAFT_PART_INSTALL}/meta/gui/codium.png"
+      mkdir -p "${CRAFT_PART_INSTALL}/meta/gui"
+      cp "${CRAFT_PART_INSTALL}/usr/share/codium/resources/app/resources/linux/code.png" "${CRAFT_PART_INSTALL}/meta/gui/codium.png"
       # Update paths
-      sed -i 's|Exec=/usr/share/codium/codium|Exec=codium --force-user-env|g' "${SNAPCRAFT_PART_INSTALL}/usr/share/applications/codium.desktop"
-      sed -i 's|Exec=/usr/share/codium/codium|Exec=codium --force-user-env|g' "${SNAPCRAFT_PART_INSTALL}/usr/share/applications/codium-url-handler.desktop"
-      sed -i 's|Icon=vscodium|Icon=${SNAP}/meta/gui/codium.png|g' "${SNAPCRAFT_PART_INSTALL}/usr/share/applications/codium.desktop"
-      sed -i 's|Icon=vscodium|Icon=${SNAP}/meta/gui/codium.png|g' "${SNAPCRAFT_PART_INSTALL}/usr/share/applications/codium-url-handler.desktop"
+      # sed -i 's|Exec=/usr/share/codium/codium|Exec=codium --force-user-env|g' "${CRAFT_PART_INSTALL}/usr/share/applications/codium.desktop"
+      # sed -i 's|Exec=/usr/share/codium/codium|Exec=codium --force-user-env|g' "${CRAFT_PART_INSTALL}/usr/share/applications/codium-url-handler.desktop"
+      sed -i 's|Icon=vscodium|Icon=${SNAP}/meta/gui/codium.png|g' "${CRAFT_PART_INSTALL}/usr/share/applications/codium.desktop"
+      sed -i 's|Icon=vscodium|Icon=${SNAP}/meta/gui/codium.png|g' "${CRAFT_PART_INSTALL}/usr/share/applications/codium-url-handler.desktop"
     build-packages:
       - wget
       - jq
     stage-packages:
-      - ca-certificates
       - libasound2
-      - libatk-bridge2.0-0
       - libatk1.0-0
-      - libatspi2.0-0
       - libcairo2
-      - libcanberra-gtk3-module
-      - libcurl3-gnutls
-      - libcurl3-nss
-      - libcurl4
-      - libdrm2
       - libgbm1
-      - libgl1
       - libglib2.0-0
       - libgtk-3-0
-      - libibus-1.0-5
       - libnss3
       - libpango-1.0-0
       - libsecret-1-0
+      - libtiff5
       - libxcomposite1
       - libxdamage1
       - libxfixes3
@@ -66,10 +57,9 @@ parts:
       - libxkbfile1
       - libxrandr2
       - libxss1
-      - locales-all
-      - packagekit-gtk3-module
-      - xdg-utils
     prime:
+      - -etc
+      - -var
       - -usr/share/doc
       - -usr/share/fonts
       - -usr/share/icons
@@ -80,10 +70,10 @@ parts:
       - enable-patchelf
     override-prime: |
       set -eux
-      snapcraftctl prime
-      for snap in "core20"; do
-        cd "/snap/${snap}/current/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}"
-        find . -type f,l -name "*.so*" -exec bash -c "rm -f ${SNAPCRAFT_PRIME}/{}*" \;
+      craftctl default
+      for snap in "core22"; do
+        cd "/snap/${snap}/current/"
+        find . -type f,l -name "*.so*" -exec bash -c "rm -rf ${CRAFT_PRIME}/{}*" \;
       done
 
   electron-launch:
@@ -94,10 +84,14 @@ parts:
 
 apps:
   codium:
-    command: electron-launch $SNAP/usr/share/codium/bin/codium --no-sandbox
+    command: usr/share/codium/bin/codium --no-sandbox
+    command-chain:
+      - electron-launch
     desktop: usr/share/applications/codium.desktop
     common-id: codium.desktop
 
   url-handler:
-    command: electron-launch $SNAP/usr/share/codium/bin/codium --open-url --no-sandbox
+    command: usr/share/codium/bin/codium --open-url --no-sandbox
+    command-chain:
+      - electron-launch
     desktop: usr/share/applications/codium-url-handler.desktop


### PR DESCRIPTION
Currently tested in

- [x]  Ubuntu 23.10
- [x] Kde Neon

Needed

- [ ] Ubuntu 20.04

Better if can be done

- [ ] Ubuntu 18.04
- [ ] Ubuntu 22.04

The error is gone. Hopefully it'll work fine