### PR TITLE
[i18n] Windows Installer - Fix minor "contect" typo

### DIFF
--- a/build/windows/msi/i18n/vscodium.en-us.wxl
+++ b/build/windows/msi/i18n/vscodium.en-us.wxl
@@ -13,9 +13,9 @@
   <String Id="FeatureFileTypeAssociationsTitle">File Associations</String>
   <String Id="FeatureFileTypeAssociationsDescription">Register @@PRODUCT_NAME@@ as an editor for supported file types.</String>
   <String Id="FeatureAddContextMenuFilesTitle">Files context menu</String>
-  <String Id="FeatureAddContextMenuFilesDescription">Add "Open with @@PRODUCT_NAME@@" action to Windows Explorer file contect menu.</String>
+  <String Id="FeatureAddContextMenuFilesDescription">Add "Open with @@PRODUCT_NAME@@" action to Windows Explorer file context menu.</String>
   <String Id="FeatureAddContextMenuFoldersTitle">Directory context menu</String>
-  <String Id="FeatureAddContextMenuFoldersDescription">Add "Open with @@PRODUCT_NAME@@" action to Windows Explorer directory contect menu.</String>
+  <String Id="FeatureAddContextMenuFoldersDescription">Add "Open with @@PRODUCT_NAME@@" action to Windows Explorer directory context menu.</String>
   <String Id="FeatureEnvironmentTitle">Add to PATH</String>
   <String Id="FeatureEnvironmentDescription">Add @@PRODUCT_NAME@@ to PATH environment variable. Available after restart.</String>
   <String Id="LaunchApplication">Launch @@PRODUCT_NAME@@</String>


### PR DESCRIPTION
Greetings! I just tried vscodium, and its really good. However when using the installer > advanced options i saw incorrect spelling of "context". 
