### PR TITLE
Remove deprecated "unity-launch" flag from Linux desktop files

### DIFF
--- a/src/insider/resources/linux/code.desktop
+++ b/src/insider/resources/linux/code.desktop
@@ -2,7 +2,7 @@
 Name=@@NAME_LONG@@
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=@@EXEC@@ --unity-launch %F
+Exec=@@EXEC@@ %F
 Icon=@@ICON@@
 Type=Application
 StartupNotify=false

--- a/src/stable/resources/linux/code.desktop
+++ b/src/stable/resources/linux/code.desktop
@@ -2,7 +2,7 @@
 Name=@@NAME_LONG@@
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=@@EXEC@@ --unity-launch %F
+Exec=@@EXEC@@ %F
 Icon=@@ICON@@
 Type=Application
 StartupNotify=false


### PR DESCRIPTION
Upstream [deprecated and removed](https://github.com/microsoft/vscode/commit/0da22a226000adc62cf7b8a83b045668fb8a9296) "unity-launch" flag.
This commit removes this redundant flag from Linux desktop files since it breaks file opening from the outside.

Closes #1865 