### PR TITLE
Add experimental riscv64 builds

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -149,6 +149,9 @@ jobs:
         - vscode_arch: armhf
           npm_arch: arm
           image: vscodium/vscodium-linux-build-agent:bionic-armhf
+        - vscode_arch: riscv64
+          npm_arch: riscv64
+          image: vscodium/vscodium-linux-build-agent:focal-riscv64
     container:
       image: ${{ matrix.image }}
     env:

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -148,6 +148,9 @@ jobs:
         - vscode_arch: armhf
           npm_arch: arm
           image: vscodium/vscodium-linux-build-agent:bionic-armhf
+        - vscode_arch: riscv64
+          npm_arch: riscv64
+          image: vscodium/vscodium-linux-build-agent:focal-riscv64
     container:
       image: ${{ matrix.image }}
     env:

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -330,20 +330,26 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
       # linux-riscv64
       if [[ "${VSCODE_ARCH}" == "riscv64" || "${CHECK_ALL}" == "yes" ]]; then
-        SHOULD_BUILD_APPIMAGE="no"
-        SHOULD_BUILD_DEB="no"
-        SHOULD_BUILD_RPM="no"
-        SHOULD_BUILD_TAR="no"
+        export SHOULD_BUILD_DEB="no"
+        export SHOULD_BUILD_RPM="no"
+        export SHOULD_BUILD_APPIMAGE="no"
+      
+        if [[ -z $( contains "${APP_NAME}-linux-riscv64-${RELEASE_VERSION}.tar.gz" ) ]]; then
+          echo "Building on Linux RISC-V 64 because we have no TAR"
+          export SHOULD_BUILD="yes"
+        else
+          export SHOULD_BUILD_TAR="no"
+        fi
 
         if [[ -z $( contains "${APP_NAME_LC}-reh-linux-riscv64-${RELEASE_VERSION}.tar.gz" ) ]]; then
-          echo "Building on Linux RISC-V64 because we have no REH archive"
+          echo "Building on Linux RISC-V 64 because we have no REH archive"
           export SHOULD_BUILD="yes"
         else
           export SHOULD_BUILD_REH="no"
         fi
 
         if [[ "${SHOULD_BUILD}" != "yes" ]]; then
-          echo "Already have all the Linux PowerPC64LE builds"
+          echo "Already have all the Linux riscv64 builds"
         fi
       fi
 
@@ -394,10 +400,13 @@ else
   if [[ "${IS_SPEARHEAD}" == "yes" ]]; then
     export SHOULD_BUILD_SRC="yes"
   elif [[ "${OS_NAME}" == "linux" ]]; then
-    if [[ "${VSCODE_ARCH}" == "ppc64le" || "${VSCODE_ARCH}" == "riscv64" ]]; then
+    if [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
       SHOULD_BUILD_DEB="no"
       SHOULD_BUILD_RPM="no"
       SHOULD_BUILD_TAR="no"
+    elif [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
+      SHOULD_BUILD_DEB="no"
+      SHOULD_BUILD_RPM="no"
     fi
     if [[ "${VSCODE_ARCH}" != "x64" ]]; then
       export SHOULD_BUILD_APPIMAGE="no"

--- a/package_linux_bin.sh
+++ b/package_linux_bin.sh
@@ -22,6 +22,17 @@ if [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   export VSCODE_SYSROOT_PREFIX='-glibc-2.28'
 fi
 
+if [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
+  export VSCODE_ELECTRON_REPO='riscv-forks/electron-riscv-releases'
+  export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+  export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+  ELECTRON_VERSION="v29.4.0"
+  # Look for releases here if electron version used by vscode changed
+  # https://github.com/riscv-forks/electron-riscv-releases/releases
+  export VSCODE_ELECTRON_TAG="${ELECTRON_VERSION}.riscv2"
+  echo "7244465fe0c1a6ac6e34fe765a9d90fe0017b1a6d3406fd6b8dd9f5d2c8c9df5 *electron-v29.4.0-linux-riscv64.zip" >> build/checksums/electron.txt 
+fi
+
 if [[ -d "../patches/${OS_NAME}/client/" ]]; then
   for file in "../patches/${OS_NAME}/client/"*.patch; do
     if [[ -f "${file}" ]]; then

--- a/patches/ppc64le-and-riscv64-support.patch
+++ b/patches/ppc64le-and-riscv64-support.patch
@@ -1,5 +1,5 @@
 diff --git a/build/azure-pipelines/linux/setup-env.sh b/build/azure-pipelines/linux/setup-env.sh
-index e42a6b12b1f..b31af12b086 100755
+index 9bfbf9ab41a..3064f783d8c 100755
 --- a/build/azure-pipelines/linux/setup-env.sh
 +++ b/build/azure-pipelines/linux/setup-env.sh
 @@ -7,6 +7,10 @@ if [ "$SYSROOT_ARCH" == "x64" ]; then
@@ -97,10 +97,33 @@ index 6f8144b0954..8a8195e9b66 100644
  
  BUILD_TARGETS.forEach(buildTarget => {
 diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
-index e1507e0424f..80ed8d91a41 100644
+index 3b1aeafd080..8363dae382c 100644
 --- a/build/gulpfile.vscode.js
 +++ b/build/gulpfile.vscode.js
-@@ -429,6 +429,8 @@ const BUILD_TARGETS = [
+@@ -339,11 +339,21 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
+ 			all = es.merge(all, shortcut);
+ 		}
+ 
++		const electronOverride = {};
++		if (process.env.VSCODE_ELECTRON_REPO) {
++			// electron doesn't support riscv64 and ppc64le, override the repo with `VSCODE_ELECTRON_REPO`.
++			electronOverride.repo = process.env.VSCODE_ELECTRON_REPO;
++		}
++
++		if (process.env.VSCODE_ELECTRON_TAG) {
++			electronOverride.tag = process.env.VSCODE_ELECTRON_TAG;
++		}
++
+ 		let result = all
+ 			.pipe(util.skipDirectories())
+ 			.pipe(util.fixWin32DirectoryPermissions())
+ 			.pipe(filter(['**', '!**/.github/**'], { dot: true })) // https://github.com/microsoft/vscode/issues/116523
+-			.pipe(electron({ ...config, platform, arch: arch === 'armhf' ? 'arm' : arch, ffmpegChromium: false }))
++			.pipe(electron({ ...config, ...electronOverride, platform, arch: arch === 'armhf' ? 'arm' : arch, ffmpegChromium: false }))
+ 			.pipe(filter(['**', '!LICENSE', '!version'], { dot: true }));
+ 
+ 		if (platform === 'linux') {
+@@ -432,6 +442,8 @@ const BUILD_TARGETS = [
  	{ platform: 'linux', arch: 'x64' },
  	{ platform: 'linux', arch: 'armhf' },
  	{ platform: 'linux', arch: 'arm64' },
@@ -181,10 +204,10 @@ index 92f8065f262..b86b4dba2b8 100644
  	cmd.push(`-l${chromiumSysroot}/usr/lib`);
  	cmd.push(`-L${vscodeSysroot}/debian/libxkbfile1/DEBIAN/shlibs`);
 diff --git a/build/linux/debian/dep-lists.js b/build/linux/debian/dep-lists.js
-index bdb265b6fec..4695f335416 100644
+index d843c090063..3b869cbbe6d 100644
 --- a/build/linux/debian/dep-lists.js
 +++ b/build/linux/debian/dep-lists.js
-@@ -140,6 +140,85 @@ exports.referenceGeneratedDepsByArch = {
+@@ -139,6 +139,85 @@ exports.referenceGeneratedDepsByArch = {
          'libxkbfile1 (>= 1:1.1.0)',
          'libxrandr2',
          'xdg-utils (>= 1.0.2)'
@@ -272,10 +295,10 @@ index bdb265b6fec..4695f335416 100644
  //# sourceMappingURL=dep-lists.js.map
 \ No newline at end of file
 diff --git a/build/linux/debian/dep-lists.ts b/build/linux/debian/dep-lists.ts
-index 3d6c2eba6e9..b8987ea7579 100644
+index 4028370cd02..ff4df2f08cb 100644
 --- a/build/linux/debian/dep-lists.ts
 +++ b/build/linux/debian/dep-lists.ts
-@@ -140,5 +140,84 @@ export const referenceGeneratedDepsByArch = {
+@@ -139,5 +139,84 @@ export const referenceGeneratedDepsByArch = {
  		'libxkbfile1 (>= 1:1.1.0)',
  		'libxrandr2',
  		'xdg-utils (>= 1.0.2)'
@@ -401,7 +424,7 @@ index feca7d3fa9d..f075ebcba75 100644
      console.log(`Fetching ${expectedName} for ${triple}`);
      const checksumSha256 = getVSCodeSysrootChecksum(expectedName);
 diff --git a/build/linux/debian/install-sysroot.ts b/build/linux/debian/install-sysroot.ts
-index aa417dcc722..02b1cc4e057 100644
+index aa417dcc722..58f0eeefeff 100644
 --- a/build/linux/debian/install-sysroot.ts
 +++ b/build/linux/debian/install-sysroot.ts
 @@ -82,7 +82,10 @@ async function fetchUrl(options: IFetchOptions, retries = 10, retryDelay = 1000)
@@ -409,10 +432,10 @@ index aa417dcc722..02b1cc4e057 100644
  		const version = '20240129-253798';
  		try {
 -			const response = await fetch(`https://api.github.com/repos/Microsoft/vscode-linux-build-agent/releases/tags/v${version}`, {
-+				// if VSCODE_SYSROOT_REPO and VSCODE_SYSROOT_VERSION are set, use those instead
-+				const repo = process.env['VSCODE_SYSROOT_REPO'] ?? 'Microsoft/vscode-linux-build-agent';
-+				const actualVersion = process.env['VSCODE_SYSROOT_VERSION'] ?? version;
-+				const response = await fetch(`https://api.github.com/repos/${repo}/releases/tags/v${actualVersion}`, {
++			// if VSCODE_SYSROOT_REPO and VSCODE_SYSROOT_VERSION are set, use those instead
++			const repo = process.env['VSCODE_SYSROOT_REPO'] ?? 'Microsoft/vscode-linux-build-agent';
++			const actualVersion = process.env['VSCODE_SYSROOT_VERSION'] ?? version;
++			const response = await fetch(`https://api.github.com/repos/${repo}/releases/tags/v${actualVersion}`, {
  				headers: ghApiHeaders,
  				signal: controller.signal as any /* Typings issue with lib.dom.d.ts */
  			});
@@ -469,10 +492,10 @@ index e97485ef128..24fe452f7fe 100644
 +	return ['amd64', 'armhf', 'arm64', 'ppc64el', 'riscv64'].includes(s);
  }
 diff --git a/build/linux/rpm/dep-lists.js b/build/linux/rpm/dep-lists.js
-index bd84fc146dc..50b195e1a98 100644
+index 8be477290bb..5841d4769de 100644
 --- a/build/linux/rpm/dep-lists.js
 +++ b/build/linux/rpm/dep-lists.js
-@@ -310,6 +310,106 @@ exports.referenceGeneratedDepsByArch = {
+@@ -314,6 +314,106 @@ exports.referenceGeneratedDepsByArch = {
          'rpmlib(FileDigests) <= 4.6.0-1',
          'rtld(GNU_HASH)',
          'xdg-utils'
@@ -581,10 +604,10 @@ index bd84fc146dc..50b195e1a98 100644
  //# sourceMappingURL=dep-lists.js.map
 \ No newline at end of file
 diff --git a/build/linux/rpm/dep-lists.ts b/build/linux/rpm/dep-lists.ts
-index 82a4fe7698d..1ba4c5848e3 100644
+index 24b18d504c8..924e62666f9 100644
 --- a/build/linux/rpm/dep-lists.ts
 +++ b/build/linux/rpm/dep-lists.ts
-@@ -309,5 +309,105 @@ export const referenceGeneratedDepsByArch = {
+@@ -313,5 +313,105 @@ export const referenceGeneratedDepsByArch = {
  		'rpmlib(FileDigests) <= 4.6.0-1',
  		'rtld(GNU_HASH)',
  		'xdg-utils'
@@ -820,10 +843,10 @@ index 079557869e3..c057746b870 100644
  
  if [ "$OS_ID" != "alpine" ]; then
 diff --git a/src/vs/platform/extensionManagement/common/extensionManagement.ts b/src/vs/platform/extensionManagement/common/extensionManagement.ts
-index 665ea2e18df..d23ba6c8a76 100644
+index 183f2582871..e13fe72513c 100644
 --- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
 +++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
-@@ -33,6 +33,8 @@ export function TargetPlatformToString(targetPlatform: TargetPlatform) {
+@@ -39,6 +39,8 @@ export function TargetPlatformToString(targetPlatform: TargetPlatform) {
  		case TargetPlatform.LINUX_X64: return 'Linux 64 bit';
  		case TargetPlatform.LINUX_ARM64: return 'Linux ARM 64';
  		case TargetPlatform.LINUX_ARMHF: return 'Linux ARM';
@@ -832,7 +855,7 @@ index 665ea2e18df..d23ba6c8a76 100644
  
  		case TargetPlatform.ALPINE_X64: return 'Alpine Linux 64 bit';
  		case TargetPlatform.ALPINE_ARM64: return 'Alpine ARM 64';
-@@ -56,6 +58,8 @@ export function toTargetPlatform(targetPlatform: string): TargetPlatform {
+@@ -62,6 +64,8 @@ export function toTargetPlatform(targetPlatform: string): TargetPlatform {
  		case TargetPlatform.LINUX_X64: return TargetPlatform.LINUX_X64;
  		case TargetPlatform.LINUX_ARM64: return TargetPlatform.LINUX_ARM64;
  		case TargetPlatform.LINUX_ARMHF: return TargetPlatform.LINUX_ARMHF;
@@ -841,7 +864,7 @@ index 665ea2e18df..d23ba6c8a76 100644
  
  		case TargetPlatform.ALPINE_X64: return TargetPlatform.ALPINE_X64;
  		case TargetPlatform.ALPINE_ARM64: return TargetPlatform.ALPINE_ARM64;
-@@ -91,6 +95,12 @@ export function getTargetPlatform(platform: Platform | 'alpine', arch: string |
+@@ -97,6 +101,12 @@ export function getTargetPlatform(platform: Platform | 'alpine', arch: string |
  			if (arch === 'arm') {
  				return TargetPlatform.LINUX_ARMHF;
  			}


### PR DESCRIPTION
With a performance issue(https://github.com/riscv-forks/electron/issues/1) fixed, I think the riscv64 port of electron is mostly ready for VSCodium. There are still some corner cases that lead to segfault but it's already suitable for usage on real riscv64 hardware.

This PR add riscv64 builds to vscodium.

Official electron doesn't support riscv64 so I used a fork maintained by myself.

BTW I noticed some of the patches modifies the compiled javascript files. I think it's cleaner to directly modify the typescript source file and compile ts files to javascrpt.

I haven't implemented riscv64 support in sysroot scripts so this PR only covers a basic riscv64 build, without DEB and RPM targets.

Here's a screenshot:

VSCodium 1.90 running on 64 core SG2042.

The window on the right shows using open-remote-ssh plugin to connect to x86_64 host from riscv64.

![Screenshot_20_10_1](https://github.com/VSCodium/vscodium/assets/18085551/cd25086b-8b70-45c2-a8b6-d7baedd71ac1)
