### PR TITLE
build(riscv): Check electron version and bump to 29.4.0.riscv3

### DIFF
--- a/package_linux_bin.sh
+++ b/package_linux_bin.sh
@@ -34,8 +34,8 @@ if [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
     echo "Electron RISC-V binary version doesn't match target electron version!"
     exit 1
   fi
-  export VSCODE_ELECTRON_TAG="v${ELECTRON_VERSION}.riscv2"
-  echo "7244465fe0c1a6ac6e34fe765a9d90fe0017b1a6d3406fd6b8dd9f5d2c8c9df5 *electron-v29.4.0-linux-riscv64.zip" >> build/checksums/electron.txt
+  export VSCODE_ELECTRON_TAG="v${ELECTRON_VERSION}.riscv3"
+  echo "c2b55b6fee59dd2f29138b0052536d5c254c04c29bc322bd3e877bb457799fca *electron-v29.4.0-linux-riscv64.zip" >> build/checksums/electron.txt
 fi
 
 if [[ -d "../patches/linux/client/" ]]; then

--- a/package_linux_bin.sh
+++ b/package_linux_bin.sh
@@ -26,10 +26,15 @@ if [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
   export VSCODE_ELECTRON_REPO='riscv-forks/electron-riscv-releases'
   export ELECTRON_SKIP_BINARY_DOWNLOAD=1
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-  ELECTRON_VERSION="v29.4.0"
-  # Look for releases here if electron version used by vscode changed
-  # https://github.com/riscv-forks/electron-riscv-releases/releases
-  export VSCODE_ELECTRON_TAG="${ELECTRON_VERSION}.riscv2"
+  ELECTRON_VERSION="29.4.0"
+  if [[ "${ELECTRON_VERSION}" != "$(yarn config get target)" ]]; then
+    # Fail the pipeline if electron target doesn't match what is used. 
+    # Look for releases here if electron version used by vscode changed:
+    # https://github.com/riscv-forks/electron-riscv-releases/releases
+    echo "Electron RISC-V binary version doesn't match target electron version!"
+    exit 1
+  fi
+  export VSCODE_ELECTRON_TAG="v${ELECTRON_VERSION}.riscv2"
   echo "7244465fe0c1a6ac6e34fe765a9d90fe0017b1a6d3406fd6b8dd9f5d2c8c9df5 *electron-v29.4.0-linux-riscv64.zip" >> build/checksums/electron.txt
 fi
 


### PR DESCRIPTION
- Add a check that fails when the riscv electron version doesn't match `.yarnrc`.
  - This ensures that we won't produce broken releases when they don't match and signal that the riscv electron version should be bumped.
- Bump riscv electron to v29.4.0.riscv3 for https://github.com/riscv-forks/electron/issues/2