### PR TITLE
feat(1.94.1): manually set correct commit id

### DIFF
--- a/stable.json
+++ b/stable.json
@@ -1,4 +1,4 @@
 {
-  "tag": "1.94.0",
-  "commit": "d78a74bcdfad14d5d3b1b782f87255d802b57511"
+  "tag": "1.94.1",
+  "commit": "acb2ed666e6254b03ec48e3e7c0b78960ce4350d"
 }


### PR DESCRIPTION
MS update API doesn't report the correct commit Id so I set it manually.