### PR TITLE
fix(riscv64): bump nodejs to 20.16.0

### DIFF
--- a/package_linux_reh.sh
+++ b/package_linux_reh.sh
@@ -23,7 +23,8 @@ if [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   GLIBC_VERSION="2.28"
 elif [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
   # Unofficial RISC-V nodejs builds doesn't provide v16.x
-  NODE_VERSION="18.18.1"
+  # Node 18 is buggy so use 20 here for now: https://github.com/VSCodium/vscodium/issues/2060
+  NODE_VERSION="20.16.0"
 fi
 
 export VSCODE_PLATFORM='linux'


### PR DESCRIPTION
Fix #2060