### PR TITLE
build(windows): add signing with SignPath

### DIFF
--- a/.github/workflows/insider-windows.yml
+++ b/.github/workflows/insider-windows.yml
@@ -44,7 +44,6 @@ jobs:
       matrix:
         vscode_arch:
           - x64
-          # - ia32
           - arm64
     outputs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -30,7 +30,6 @@ env:
   VERSIONS_REPOSITORY: ${{ github.repository_owner }}/versions
   VSCODE_QUALITY: stable
 
-
 jobs:
   build:
     runs-on: windows-2019
@@ -44,7 +43,6 @@ jobs:
       matrix:
         vscode_arch:
           - x64
-          # - ia32
           - arm64
     outputs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
@@ -83,6 +81,7 @@ jobs:
 
       - name: Check existing VSCodium tags/releases
         env:
+          DISABLE_MSI: ${{ vars.DISABLE_STABLE_MSI }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./check_tags.sh
         if: env.SHOULD_DEPLOY == 'yes' || github.event.inputs.generate_assets == 'true'
@@ -97,6 +96,34 @@ jobs:
 
       - name: Prepare assets
         run: ./prepare_assets.sh
+        if: env.SHOULD_BUILD == 'yes' && (env.SHOULD_DEPLOY == 'yes' || github.event.inputs.generate_assets == 'true')
+
+      - name: Upload unsigned artifacts
+        id: upload-unsigned-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ matrix.vscode_arch }}
+          path: |
+            assets/*.exe
+            assets/*.msi
+          retention-days: 1
+        if: env.SHOULD_BUILD == 'yes' && (env.SHOULD_DEPLOY == 'yes' || github.event.inputs.generate_assets == 'true')
+
+      - name: Signing
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ secrets.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ secrets.SIGNPATH_POLICY_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-artifacts.outputs.artifact-id }}
+          artifact-configuration-slug: ${{ matrix.vscode_arch }}
+          wait-for-completion: true
+          output-artifact-directory: assets/
+        if: env.SHOULD_BUILD == 'yes' && (env.SHOULD_DEPLOY == 'yes' || github.event.inputs.generate_assets == 'true')
+
+      - name: Prepare checksums
+        run: ./prepare_checksums.sh
         if: env.SHOULD_BUILD == 'yes' && (env.SHOULD_DEPLOY == 'yes' || github.event.inputs.generate_assets == 'true')
 
       - name: Release

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ The minimal version is limited by the core component Electron, you may want to c
     <td><a href="https://www.macstadium.com" target="_blank"><img src="https://images.prismic.io/macstadium/66fbce64-707e-41f3-b547-241908884716_MacStadium_Logo.png?w=128&q=75" width="128" height="49" alt="MacStadium logo" /></a></td>
     <td>for providing a Mac mini M1</td>
   </tr>
+   <tr>
+    <td><a href="https://signpath.org/" target="_blank"><img src="https://about.signpath.io/assets/signpath-logo.svg" width="128" height="26" alt="SignPath logo" /></a></td>
+    <td>for Windows certificate</td>
+  </tr>
   <tr>
     <td><a href="https://github.com/daiyam" target="_blank">@daiyam</a></td>
     <td>for macOS certificate</td>


### PR DESCRIPTION
This PR is adding the signing of the `.exe` and `.msi` installers.
It's provided by [SignPath.io](https://signpath.io) and the certificate is by the [SignPath Foundation](https://signpath.org).