### PR TITLE
Upgrade `macos-12` to `macos-13`

### DIFF
--- a/.github/workflows/stable-macos.yml
+++ b/.github/workflows/stable-macos.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-12
+          - runner: macos-13
             vscode_arch: x64
           # - runner: macos-14
           - runner: [self-hosted, macOS, ARM64]


### PR DESCRIPTION
The x64 runner image `macos-12` is deprecated according to https://github.com/actions/runner-images?tab=readme-ov-file#available-images 

The PR upgrades the it to a newer `macos-13`

The latest x64 image is `macos-latest-large` or `macos-14-large` which seems to be a paid feature