### PR TITLE
fix appimage build by setting ARCH env

### DIFF
--- a/build/linux/appimage/build.sh
+++ b/build/linux/appimage/build.sh
@@ -19,6 +19,8 @@ if [[ "${VSCODE_ARCH}" == "x64" ]]; then
 
   chmod +x ./pkg2appimage.AppImage
 
+  export ARCH=x86_64
+
   ./pkg2appimage.AppImage --appimage-extract && mv ./squashfs-root ./pkg2appimage.AppDir
 
   # add update's url


### PR DESCRIPTION
This patch restores the appimage builds by setting ARCH=x86_64 env to fix the building error.

Fixes #2003 