### PR TITLE
add s390x support for REH

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -279,6 +279,8 @@ jobs:
         - slug: LOONG64
           vscode_arch: loong64
           npm_arch: loong64
+        - vscode_arch: s390x
+          npm_arch: s390x
     env:
       BUILD_SOURCEVERSION: ${{ needs.compile.outputs.BUILD_SOURCEVERSION }}
       DISABLED: ${{ vars[format('DISABLE_INSIDER_LINUX_REH_{0}', matrix.slug)] }}

--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -279,7 +279,8 @@ jobs:
         - slug: LOONG64
           vscode_arch: loong64
           npm_arch: loong64
-        - vscode_arch: s390x
+        - slug: S390X
+          vscode_arch: s390x
           npm_arch: s390x
     env:
       BUILD_SOURCEVERSION: ${{ needs.compile.outputs.BUILD_SOURCEVERSION }}

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -277,7 +277,8 @@ jobs:
         - slug: LOONG64
           vscode_arch: loong64
           npm_arch: loong64
-        - vscode_arch: s390x
+        - slug: S390X
+          vscode_arch: s390x
           npm_arch: s390x
     env:
       BUILD_SOURCEVERSION: ${{ needs.compile.outputs.BUILD_SOURCEVERSION }}

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -277,6 +277,8 @@ jobs:
         - slug: LOONG64
           vscode_arch: loong64
           npm_arch: loong64
+        - vscode_arch: s390x
+          npm_arch: s390x
     env:
       BUILD_SOURCEVERSION: ${{ needs.compile.outputs.BUILD_SOURCEVERSION }}
       DISABLED: ${{ vars[format('DISABLE_STABLE_LINUX_REH_{0}', matrix.slug)] }}

--- a/build/build.sh
+++ b/build/build.sh
@@ -61,6 +61,8 @@ elif [[ "${UNAME_ARCH}" == "riscv64" ]]; then
   export VSCODE_ARCH="riscv64"
 elif [[ "${UNAME_ARCH}" == "loongarch64" ]]; then
   export VSCODE_ARCH="loong64"
+elif [[ "${UNAME_ARCH}" == "s390x" ]]; then
+  export VSCODE_ARCH="s390x"
 else
   export VSCODE_ARCH="x64"
 fi

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -452,6 +452,32 @@ elif [[ "${ASSETS}" != "null" ]]; then
         fi
       fi
 
+      # linux-s390x
+      if [[ "${VSCODE_ARCH}" == "s390x" || "${CHECK_ALL}" == "yes" ]]; then
+        SHOULD_BUILD_APPIMAGE="no"
+        SHOULD_BUILD_DEB="no"
+        SHOULD_BUILD_RPM="no"
+        SHOULD_BUILD_TAR="no"
+
+        if [[ -z $( contains "${APP_NAME_LC}-reh-linux-s390x-${RELEASE_VERSION}.tar.gz" ) ]]; then
+          echo "Building on Linux s390x because we have no REH archive"
+          export SHOULD_BUILD="yes"
+        else
+          export SHOULD_BUILD_REH="no"
+        fi
+
+        if [[ -z $( contains "${APP_NAME_LC}-reh-web-linux-s390x-${RELEASE_VERSION}.tar.gz" ) ]]; then
+          echo "Building on Linux s390x because we have no REH-web archive"
+          export SHOULD_BUILD="yes"
+        else
+          export SHOULD_BUILD_REH_WEB="no"
+        fi
+
+        if [[ "${SHOULD_BUILD}" != "yes" ]]; then
+          echo "Already have all the Linux s390x builds"
+        fi
+      fi
+
       # linux-x64
       if [[ "${VSCODE_ARCH}" == "x64" || "${CHECK_ALL}" == "yes" ]]; then
         if [[ -z $( contains "amd64.deb" ) ]]; then

--- a/package_linux_reh.sh
+++ b/package_linux_reh.sh
@@ -61,6 +61,14 @@ elif [[ "${VSCODE_ARCH}" == "loong64" ]]; then
   export VSCODE_SKIP_SETUPENV=1
   export VSCODE_NODEJS_SITE='https://unofficial-builds.nodejs.org'
   export VSCODE_NODEJS_URLROOT='/download/release'
+elif [[ "${VSCODE_ARCH}" == "s390x" ]]; then
+  GLIBC_VERSION="2.28"
+  VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="agrapentin/vscode-linux-build-agent:focal-devtoolset-s390x"
+
+  export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+  export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+  export VSCODE_SYSROOT_REPOSITORY='andreasgrapentin/vscode-linux-build-agent'
+  export VSCODE_SYSROOT_VERSION='20241108'
 fi
 
 export VSCODE_PLATFORM='linux'

--- a/package_linux_reh.sh
+++ b/package_linux_reh.sh
@@ -63,11 +63,11 @@ elif [[ "${VSCODE_ARCH}" == "loong64" ]]; then
   export VSCODE_NODEJS_URLROOT='/download/release'
 elif [[ "${VSCODE_ARCH}" == "s390x" ]]; then
   GLIBC_VERSION="2.28"
-  VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="agrapentin/vscode-linux-build-agent:focal-devtoolset-s390x"
+  VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="vscodium/vscodium-linux-build-agent:focal-devtoolset-s390x"
 
   export ELECTRON_SKIP_BINARY_DOWNLOAD=1
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-  export VSCODE_SYSROOT_REPOSITORY='andreasgrapentin/vscode-linux-build-agent'
+  export VSCODE_SYSROOT_REPOSITORY='VSCodium/vscode-linux-build-agent'
   export VSCODE_SYSROOT_VERSION='20241108'
 fi
 

--- a/patches/linux/arch-4-s390x.patch
+++ b/patches/linux/arch-4-s390x.patch
@@ -23,7 +23,7 @@ index 0b5f38c..9f3b02b 100644
 +++ b/build/checksums/vscode-sysroot.txt
 @@ -7 +7,2 @@
  fa8176d27be18bb0eeb7f55b0fa22255050b430ef68c29136599f02976eb0b1b  powerpc64le-linux-gnu-glibc-2.28.tar.gz
-+c16511a2466a78d22c2b33d89f825fcb3fcd085ebfd099bb0c852ed730e0e78a  s390x-linux-gnu-glibc-2.28.tar.gz
++7055f3d40e7195fb1e13f0fbaf5ffadf781bddaca5fd5e0d9972f4157a203fb5  s390x-linux-gnu-glibc-2.28.tar.gz
 diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
 index d0770d6..8c83c13 100644
 --- a/build/gulpfile.reh.js

--- a/patches/linux/arch-4-s390x.patch
+++ b/patches/linux/arch-4-s390x.patch
@@ -428,38 +428,3 @@ index 5973d4d..a7d6298 100644
  	LINUX_LOONG64 = 'linux-loong64',
 +	LINUX_S390X = 'linux-s390x',
  
-diff --git a/package-lock.json b/package-lock.json
-index 7b02996..4642486 100644
---- a/package-lock.json
-+++ b/package-lock.json
-@@ -17875,10 +17875,11 @@
-       }
-     },
-     "node_modules/web-tree-sitter": {
--      "version": "0.20.8",
--      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
--      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
--      "dev": true
-+      "version": "0.23.0",
-+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.23.0.tgz",
-+      "integrity": "sha512-p1T+ju2H30fpVX2q5yr+Wv/NfdMMWMjQp9Q+4eEPrHAJpPFh9DPfI2Yr9L1f5SA5KPE+g1cNUqPbpihxUDzmVw==",
-+      "dev": true,
-+      "license": "MIT"
-     },
-     "node_modules/webidl-conversions": {
-       "version": "3.0.1",
-diff --git a/package.json b/package.json
-index 7e0de18..4ceaded 100644
---- a/package.json
-+++ b/package.json
-@@ -226,7 +226,10 @@
-     },
-     "@parcel/watcher@2.1.0": {
-       "node-addon-api": "7.1.0"
-+    },
-+    "@vscode/l10n-dev@0.0.35": {
-+      "web-tree-sitter": "0.23.0"
-     }
-   },
-   "repository": {
-     "type": "git",

--- a/patches/linux/arch-4-s390x.patch
+++ b/patches/linux/arch-4-s390x.patch
@@ -1,0 +1,465 @@
+diff --git a/build/azure-pipelines/linux/setup-env.sh b/build/azure-pipelines/linux/setup-env.sh
+index fbe67b0..5b2f5d8 100755
+--- a/build/azure-pipelines/linux/setup-env.sh
++++ b/build/azure-pipelines/linux/setup-env.sh
+@@ -86,2 +86,14 @@ elif [ "$npm_config_arch" == "arm" ]; then
+ 	export VSCODE_REMOTE_LDFLAGS="--sysroot=$VSCODE_SYSROOT_DIR/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sysroot -L$VSCODE_SYSROOT_DIR/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sysroot/usr/lib/powerpc64le-linux-gnu -L$VSCODE_SYSROOT_DIR/powerpc64le-linux-gnu/powerpc64le-linux-gnu/sysroot/lib/powerpc64le-linux-gnu"
++elif [ "$npm_config_arch" == "s390x" ]; then
++	# Set compiler toolchain for client native modules
++	export CC=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/bin/s390x-linux-gnu-gcc
++	export CXX=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/bin/s390x-linux-gnu-g++
++	export CXXFLAGS="--sysroot=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot"
++	export LDFLAGS="--sysroot=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot -L$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot/usr/lib/s390x-linux-gnu -L$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot/lib/s390x-linux-gnu"
++
++	# Set compiler toolchain for remote server
++	export VSCODE_REMOTE_CC=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/bin/s390x-linux-gnu-gcc
++	export VSCODE_REMOTE_CXX=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/bin/s390x-linux-gnu-g++
++	export VSCODE_REMOTE_CXXFLAGS="--sysroot=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot"
++	export VSCODE_REMOTE_LDFLAGS="--sysroot=$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot -L$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot/usr/lib/s390x-linux-gnu -L$VSCODE_SYSROOT_DIR/s390x-linux-gnu/s390x-linux-gnu/sysroot/lib/s390x-linux-gnu"
+ fi
+diff --git a/build/checksums/vscode-sysroot.txt b/build/checksums/vscode-sysroot.txt
+index 0b5f38c..9f3b02b 100644
+--- a/build/checksums/vscode-sysroot.txt
++++ b/build/checksums/vscode-sysroot.txt
+@@ -7 +7,2 @@
+ fa8176d27be18bb0eeb7f55b0fa22255050b430ef68c29136599f02976eb0b1b  powerpc64le-linux-gnu-glibc-2.28.tar.gz
++c16511a2466a78d22c2b33d89f825fcb3fcd085ebfd099bb0c852ed730e0e78a  s390x-linux-gnu-glibc-2.28.tar.gz
+diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
+index d0770d6..8c83c13 100644
+--- a/build/gulpfile.reh.js
++++ b/build/gulpfile.reh.js
+@@ -53,2 +53,3 @@ const BUILD_TARGETS = [
+ 	{ platform: 'linux', arch: 'loong64' },
++	{ platform: 'linux', arch: 's390x' },
+ 	{ platform: 'alpine', arch: 'arm64' },
+diff --git a/build/gulpfile.scan.js b/build/gulpfile.scan.js
+index cbcdddb..274d889 100644
+--- a/build/gulpfile.scan.js
++++ b/build/gulpfile.scan.js
+@@ -29,2 +29,3 @@ const BUILD_TARGETS = [
+ 	{ platform: 'linux', arch: 'loong64' },
++	{ platform: 'linux', arch: 's390x' },
+ ];
+diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
+index 95f2cf0..7395ba4 100644
+--- a/build/gulpfile.vscode.js
++++ b/build/gulpfile.vscode.js
+@@ -498,2 +498,3 @@ const BUILD_TARGETS = [
+ 	{ platform: 'linux', arch: 'loong64' },
++	{ platform: 'linux', arch: 's390x' },
+ ];
+diff --git a/build/gulpfile.vscode.linux.js b/build/gulpfile.vscode.linux.js
+index fb0e5a4..264cec1 100644
+--- a/build/gulpfile.vscode.linux.js
++++ b/build/gulpfile.vscode.linux.js
+@@ -31,3 +31,3 @@ const linuxPackageRevision = Math.floor(new Date().getTime() / 1000);
+ function getDebPackageArch(arch) {
+-	return { x64: 'amd64', armhf: 'armhf', arm64: 'arm64', ppc64le: 'ppc64el', riscv64: 'riscv64' }[arch];
++	return { x64: 'amd64', armhf: 'armhf', arm64: 'arm64', ppc64le: 'ppc64el', riscv64: 'riscv64', s390x: 's390x' }[arch];
+ }
+@@ -143,3 +143,3 @@ function getRpmBuildPath(rpmArch) {
+ function getRpmPackageArch(arch) {
+-	return { x64: 'x86_64', armhf: 'armv7hl', arm64: 'aarch64', ppc64le: 'ppc64le', riscv64: 'riscv64' }[arch];
++	return { x64: 'x86_64', armhf: 'armv7hl', arm64: 'aarch64', ppc64le: 'ppc64le', riscv64: 'riscv64', s390x: 's390x' }[arch];
+ }
+@@ -307,2 +307,3 @@ const BUILD_TARGETS = [
+ 	{ arch: 'riscv64' },
++	{ arch: 's390x' },
+ ];
+diff --git a/build/linux/debian/calculate-deps.js b/build/linux/debian/calculate-deps.js
+index 57934e6..b97d275 100644
+--- a/build/linux/debian/calculate-deps.js
++++ b/build/linux/debian/calculate-deps.js
+@@ -57,2 +57,5 @@ function calculatePackageDeps(binaryPath, arch, chromiumSysroot, vscodeSysroot)
+ 			break;
++		case 's390x':
++			cmd.push(`-l${chromiumSysroot}/usr/lib/s390x-linux-gnu`, `-l${chromiumSysroot}/lib/s390x-linux-gnu`, `-l${vscodeSysroot}/usr/lib/s390x-linux-gnu`, `-l${vscodeSysroot}/lib/s390x-linux-gnu`);
++			break;
+     }
+diff --git a/build/linux/debian/calculate-deps.ts b/build/linux/debian/calculate-deps.ts
+index c44e241..5a6e9b4 100644
+--- a/build/linux/debian/calculate-deps.ts
++++ b/build/linux/debian/calculate-deps.ts
+@@ -73,2 +73,8 @@ function calculatePackageDeps(binaryPath: string, arch: DebianArchString, chromi
+ 			break;
++		case 's390x':
++			cmd.push(`-l${chromiumSysroot}/usr/lib/s390x-linux-gnu`,
++				`-l${chromiumSysroot}/lib/s390x-linux-gnu`,
++				`-l${vscodeSysroot}/usr/lib/s390x-linux-gnu`,
++				`-l${vscodeSysroot}/lib/s390x-linux-gnu`);
++			break;
+ 	}
+diff --git a/build/linux/debian/dep-lists.js b/build/linux/debian/dep-lists.js
+index 306d91e..64377e3 100644
+--- a/build/linux/debian/dep-lists.js
++++ b/build/linux/debian/dep-lists.js
+@@ -218,2 +218,42 @@ exports.referenceGeneratedDepsByArch = {
+     ],
++    's390x': [
++        'ca-certificates',
++        'libatomic1',
++        'libasound2 (>= 1.0.17)',
++        'libatk-bridge2.0-0 (>= 2.5.3)',
++        'libatk1.0-0 (>= 2.2.0)',
++        'libatspi2.0-0 (>= 2.9.90)',
++        'libc6 (>= 2.17)',
++        'libc6 (>= 2.28)',
++        'libcairo2 (>= 1.6.0)',
++        'libcurl3-gnutls | libcurl3-nss | libcurl4 | libcurl3',
++        'libdbus-1-3 (>= 1.0.2)',
++        'libdrm2 (>= 2.4.60)',
++        'libexpat1 (>= 2.0.1)',
++        'libgbm1 (>= 17.1.0~rc2)',
++        'libglib2.0-0 (>= 2.16.0)',
++        'libglib2.0-0 (>= 2.39.4)',
++        'libgtk-3-0 (>= 3.9.10)',
++        'libgtk-3-0 (>= 3.9.10) | libgtk-4-1',
++        'libnspr4 (>= 2:4.9-2~)',
++        'libnss3 (>= 2:3.22)',
++        'libnss3 (>= 3.26)',
++        'libpango-1.0-0 (>= 1.14.0)',
++        'libsecret-1-0 (>= 0.18)',
++        'libstdc++6 (>= 4.1.1)',
++        'libstdc++6 (>= 5)',
++        'libstdc++6 (>= 5.2)',
++        'libstdc++6 (>= 6)',
++        'libx11-6',
++        'libx11-6 (>= 2:1.4.99.1)',
++        'libxcb1 (>= 1.9.2)',
++        'libxcomposite1 (>= 1:0.4.4-1)',
++        'libxdamage1 (>= 1:1.1)',
++        'libxext6',
++        'libxfixes3',
++        'libxkbcommon0 (>= 0.4.1)',
++        'libxkbfile1',
++        'libxrandr2',
++        'xdg-utils (>= 1.0.2)'
++    ],
+ };
+diff --git a/build/linux/debian/dep-lists.ts b/build/linux/debian/dep-lists.ts
+index 9f29943..aa769ad 100644
+--- a/build/linux/debian/dep-lists.ts
++++ b/build/linux/debian/dep-lists.ts
+@@ -218,2 +218,42 @@ export const referenceGeneratedDepsByArch = {
+ 	],
++	's390x': [
++		'ca-certificates',
++		'libatomic1',
++		'libasound2 (>= 1.0.17)',
++		'libatk-bridge2.0-0 (>= 2.5.3)',
++		'libatk1.0-0 (>= 2.2.0)',
++		'libatspi2.0-0 (>= 2.9.90)',
++		'libc6 (>= 2.17)',
++		'libc6 (>= 2.28)',
++		'libcairo2 (>= 1.6.0)',
++		'libcurl3-gnutls | libcurl3-nss | libcurl4 | libcurl3',
++		'libdbus-1-3 (>= 1.0.2)',
++		'libdrm2 (>= 2.4.60)',
++		'libexpat1 (>= 2.0.1)',
++		'libgbm1 (>= 17.1.0~rc2)',
++		'libglib2.0-0 (>= 2.16.0)',
++		'libglib2.0-0 (>= 2.39.4)',
++		'libgtk-3-0 (>= 3.9.10)',
++		'libgtk-3-0 (>= 3.9.10) | libgtk-4-1',
++		'libnspr4 (>= 2:4.9-2~)',
++		'libnss3 (>= 2:3.22)',
++		'libnss3 (>= 3.26)',
++		'libpango-1.0-0 (>= 1.14.0)',
++		'libsecret-1-0 (>= 0.18)',
++		'libstdc++6 (>= 4.1.1)',
++		'libstdc++6 (>= 5)',
++		'libstdc++6 (>= 5.2)',
++		'libstdc++6 (>= 6)',
++		'libx11-6',
++		'libx11-6 (>= 2:1.4.99.1)',
++		'libxcb1 (>= 1.9.2)',
++		'libxcomposite1 (>= 1:0.4.4-1)',
++		'libxdamage1 (>= 1:1.1)',
++		'libxext6',
++		'libxfixes3',
++		'libxkbcommon0 (>= 0.4.1)',
++		'libxkbfile1',
++		'libxrandr2',
++		'xdg-utils (>= 1.0.2)'
++	],
+ };
+diff --git a/build/linux/debian/install-sysroot.js b/build/linux/debian/install-sysroot.js
+index 2cd8f2d..aef739c 100644
+--- a/build/linux/debian/install-sysroot.js
++++ b/build/linux/debian/install-sysroot.js
+@@ -145,2 +145,6 @@ async function getVSCodeSysroot(arch) {
+ 	             break;
++        case 's390x':
++            expectedName = `s390x-linux-gnu${prefix}.tar.gz`;
++            triple = 's390x-linux-gnu';
++            break;
+     }
+diff --git a/build/linux/debian/install-sysroot.ts b/build/linux/debian/install-sysroot.ts
+index d8de38e..53b4866 100644
+--- a/build/linux/debian/install-sysroot.ts
++++ b/build/linux/debian/install-sysroot.ts
+@@ -162,2 +162,6 @@ export async function getVSCodeSysroot(arch: DebianArchString): Promise<string>
+ 			break;
++		case 's390x':
++			expectedName = `s390x-linux-gnu${prefix}.tar.gz`;
++			triple = 's390x-linux-gnu';
++			break;
+ 	}
+diff --git a/build/linux/debian/types.js b/build/linux/debian/types.js
+index ce21d50..2c56b9c 100644
+--- a/build/linux/debian/types.js
++++ b/build/linux/debian/types.js
+@@ -8,3 +8,3 @@ exports.isDebianArchString = isDebianArchString;
+ function isDebianArchString(s) {
+-    return ['amd64', 'armhf', 'arm64', 'ppc64el', 'riscv64'].includes(s);
++    return ['amd64', 'armhf', 'arm64', 'ppc64el', 'riscv64', 's390x'].includes(s);
+ }
+diff --git a/build/linux/debian/types.ts b/build/linux/debian/types.ts
+index e97485e..43f2434 100644
+--- a/build/linux/debian/types.ts
++++ b/build/linux/debian/types.ts
+@@ -5,6 +5,6 @@
+ 
+-export type DebianArchString = 'amd64' | 'armhf' | 'arm64' | 'ppc64el' | 'riscv64';
++export type DebianArchString = 'amd64' | 'armhf' | 'arm64' | 'ppc64el' | 'riscv64' | 's390x';
+ 
+ export function isDebianArchString(s: string): s is DebianArchString {
+-	return ['amd64', 'armhf', 'arm64', 'ppc64el', 'riscv64'].includes(s);
++	return ['amd64', 'armhf', 'arm64', 'ppc64el', 'riscv64', 's390x'].includes(s);
+ }
+diff --git a/build/linux/rpm/dep-lists.ts b/build/linux/rpm/dep-lists.ts
+index 8761e40..1885210 100644
+--- a/build/linux/rpm/dep-lists.ts
++++ b/build/linux/rpm/dep-lists.ts
+@@ -409,2 +409,102 @@ export const referenceGeneratedDepsByArch = {
+ 		'xdg-utils'
++	],
++	"s390x": [
++		'ca-certificates',
++		'ld-linux-x86-64.so.2()(64bit)',
++		'ld-linux-x86-64.so.2(GLIBC_2.3)(64bit)',
++		'ld64.so.2()(64bit)',
++		'ld64.so.2(GLIBC_2.17)(64bit)',
++		'libX11.so.6()(64bit)',
++		'libXcomposite.so.1()(64bit)',
++		'libXdamage.so.1()(64bit)',
++		'libXext.so.6()(64bit)',
++		'libXfixes.so.3()(64bit)',
++		'libXrandr.so.2()(64bit)',
++		'libasound.so.2()(64bit)',
++		'libasound.so.2(ALSA_0.9)(64bit)',
++		'libasound.so.2(ALSA_0.9.0rc4)(64bit)',
++		'libatk-1.0.so.0()(64bit)',
++		'libatk-bridge-2.0.so.0()(64bit)',
++		'libatspi.so.0()(64bit)',
++		'libc.so.6()(64bit)',
++		'libc.so.6(GLIBC_2.14)(64bit)',
++		'libc.so.6(GLIBC_2.17)(64bit)',
++		'libc.so.6(GLIBC_2.2.5)(64bit)',
++		'libc.so.6(GLIBC_2.28)(64bit)',
++		'libc.so.6(GLIBC_2.4)(64bit)',
++		'libc.so.6(GLIBC_2.9)(64bit)',
++		'libcairo.so.2()(64bit)',
++		'libcups.so.2()(64bit)',
++		'libcurl.so.4()(64bit)',
++		'libdbus-1.so.3()(64bit)',
++		'libdbus-1.so.3(LIBDBUS_1_3)(64bit)',
++		'libdl.so.2()(64bit)',
++		'libdl.so.2(GLIBC_2.17)(64bit)',
++		'libdrm.so.2()(64bit)',
++		'libexpat.so.1()(64bit)',
++		'libgbm.so.1()(64bit)',
++		'libgcc_s.so.1()(64bit)',
++		'libgcc_s.so.1(GCC_3.0)(64bit)',
++		'libgcc_s.so.1(GCC_3.4.4)(64bit)',
++		'libgio-2.0.so.0()(64bit)',
++		'libglib-2.0.so.0()(64bit)',
++		'libgobject-2.0.so.0()(64bit)',
++		'libgssapi_krb5.so.2()(64bit)',
++		'libgssapi_krb5.so.2(gssapi_krb5_2_MIT)(64bit)',
++		'libgtk-3.so.0()(64bit)',
++		'libkrb5.so.3()(64bit)',
++		'libkrb5.so.3(krb5_3_MIT)(64bit)',
++		'libm.so.6()(64bit)',
++		'libm.so.6(GLIBC_2.17)(64bit)',
++		'libm.so.6(GLIBC_2.2.5)(64bit)',
++		'libm.so.6(GLIBC_2.27)(64bit)',
++		'libnspr4.so()(64bit)',
++		'libnss3.so()(64bit)',
++		'libnss3.so(NSS_3.11)(64bit)',
++		'libnss3.so(NSS_3.12)(64bit)',
++		'libnss3.so(NSS_3.12.1)(64bit)',
++		'libnss3.so(NSS_3.2)(64bit)',
++		'libnss3.so(NSS_3.22)(64bit)',
++		'libnss3.so(NSS_3.3)(64bit)',
++		'libnss3.so(NSS_3.30)(64bit)',
++		'libnss3.so(NSS_3.4)(64bit)',
++		'libnss3.so(NSS_3.5)(64bit)',
++		'libnss3.so(NSS_3.9.2)(64bit)',
++		'libnssutil3.so()(64bit)',
++		'libnssutil3.so(NSSUTIL_3.12.3)(64bit)',
++		'libpango-1.0.so.0()(64bit)',
++		'libpthread.so.0()(64bit)',
++		'libpthread.so.0(GLIBC_2.17)(64bit)',
++		'libpthread.so.0(GLIBC_2.2.5)(64bit)',
++		'libpthread.so.0(GLIBC_2.3.2)(64bit)',
++		'libpthread.so.0(GLIBC_2.3.3)(64bit)',
++		'libsmime3.so()(64bit)',
++		'libsmime3.so(NSS_3.10)(64bit)',
++		'libsmime3.so(NSS_3.2)(64bit)',
++		'libssl3.so(NSS_3.28)(64bit)',
++		'libstdc++.so.6()(64bit)',
++		'libstdc++.so.6(CXXABI_1.3)(64bit)',
++		'libstdc++.so.6(CXXABI_1.3.5)(64bit)',
++		'libstdc++.so.6(CXXABI_1.3.8)(64bit)',
++		'libstdc++.so.6(CXXABI_1.3.9)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.11)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.14)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.15)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.18)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.19)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.20)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.21)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.22)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.5)(64bit)',
++		'libstdc++.so.6(GLIBCXX_3.4.9)(64bit)',
++		'libutil.so.1()(64bit)',
++		'libutil.so.1(GLIBC_2.2.5)(64bit)',
++		'libxcb.so.1()(64bit)',
++		'libxkbcommon.so.0()(64bit)',
++		'libxkbcommon.so.0(V_0.5.0)(64bit)',
++		'libxkbfile.so.1()(64bit)',
++		'rpmlib(FileDigests) <= 4.6.0-1',
++		'rtld(GNU_HASH)',
++		'xdg-utils'
+ 	]
+diff --git a/build/linux/rpm/types.js b/build/linux/rpm/types.js
+index a20b9c2..7b58961 100644
+--- a/build/linux/rpm/types.js
++++ b/build/linux/rpm/types.js
+@@ -8,3 +8,3 @@ exports.isRpmArchString = isRpmArchString;
+ function isRpmArchString(s) {
+-    return ['x86_64', 'armv7hl', 'aarch64', 'ppc64le', 'riscv64'].includes(s);
++    return ['x86_64', 'armv7hl', 'aarch64', 'ppc64le', 'riscv64', 's390x'].includes(s);
+ }
+diff --git a/build/linux/rpm/types.ts b/build/linux/rpm/types.ts
+index c6a01da..3f3c3f5 100644
+--- a/build/linux/rpm/types.ts
++++ b/build/linux/rpm/types.ts
+@@ -5,6 +5,6 @@
+ 
+-export type RpmArchString = 'x86_64' | 'armv7hl' | 'aarch64' | 'ppc64le' | 'riscv64';
++export type RpmArchString = 'x86_64' | 'armv7hl' | 'aarch64' | 'ppc64le' | 'riscv64' | 's390x';
+ 
+ export function isRpmArchString(s: string): s is RpmArchString {
+-	return ['x86_64', 'armv7hl', 'aarch64', 'ppc64le', 'riscv64'].includes(s);
++	return ['x86_64', 'armv7hl', 'aarch64', 'ppc64le', 'riscv64', 's390x'].includes(s);
+ }
+diff --git a/cli/src/update_service.rs b/cli/src/update_service.rs
+index 9033914..bcab676 100644
+--- a/cli/src/update_service.rs
++++ b/cli/src/update_service.rs
+@@ -221,2 +221,3 @@ pub enum Platform {
+ 	LinuxLoong64,
++	LinuxS390X,
+ 	DarwinX64,
+@@ -237,2 +238,3 @@ impl Platform {
+ 			Platform::LinuxLoong64 => Some("linux-loong64".to_owned()),
++			Platform::LinuxS390X => Some("linux-s390x".to_owned()),
+ 			Platform::DarwinX64 => Some("darwin".to_owned()),
+@@ -259,2 +261,3 @@ impl Platform {
+ 			Platform::LinuxLoong64 => "server-linux-loong64",
++			Platform::LinuxS390X => "server-linux-s390x",
+ 			Platform::DarwinX64 => "server-darwin",
+@@ -282,2 +285,3 @@ impl Platform {
+ 			Platform::LinuxLoong64 => "cli-linux-loong64",
++			Platform::LinuxS390X => "cli-linux-s390x",
+ 			Platform::DarwinX64 => "cli-darwin-x64",
+@@ -320,2 +324,4 @@ impl Platform {
+ 			Some(Platform::LinuxLoong64)
++		} else if cfg!(all(target_os = "linux", target_arch = "s390x")) {
++			Some(Platform::LinuxS390X)
+ 		} else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+@@ -351,2 +357,3 @@ impl fmt::Display for Platform {
+ 			Platform::LinuxLoong64 => "LinuxLoong64",
++			Platform::LinuxS390X => "LinuxRISCV64",
+ 			Platform::DarwinX64 => "DarwinX64",
+diff --git a/cli/src/util/prereqs.rs b/cli/src/util/prereqs.rs
+index e0fba27..4827a47 100644
+--- a/cli/src/util/prereqs.rs
++++ b/cli/src/util/prereqs.rs
+@@ -92,2 +92,4 @@ impl PreReqChecker {
+ 					Platform::LinuxLoong64
++				} else if cfg!(target_arch = "s390x") {
++					Platform::LinuxS390X
+ 				} else {
+diff --git a/resources/server/bin/helpers/check-requirements-linux.sh b/resources/server/bin/helpers/check-requirements-linux.sh
+index 8ef07a2..00dd3e2 100644
+--- a/resources/server/bin/helpers/check-requirements-linux.sh
++++ b/resources/server/bin/helpers/check-requirements-linux.sh
+@@ -59,2 +59,3 @@ case $ARCH in
+     loongarch64) LDCONFIG_ARCH="double-float";;
++    s390x)   LDCONFIG_ARCH="64bit";;
+ esac
+diff --git a/src/vs/platform/extensionManagement/common/extensionManagement.ts b/src/vs/platform/extensionManagement/common/extensionManagement.ts
+index ea7b30d..004df84 100644
+--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
++++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
+@@ -44,2 +44,3 @@ export function TargetPlatformToString(targetPlatform: TargetPlatform) {
+ 		case TargetPlatform.LINUX_LOONG64: return 'Linux Loong64';
++		case TargetPlatform.LINUX_S390X: return 'Linux S390X';
+ 
+@@ -70,2 +71,3 @@ export function toTargetPlatform(targetPlatform: string): TargetPlatform {
+ 		case TargetPlatform.LINUX_LOONG64: return TargetPlatform.LINUX_LOONG64;
++		case TargetPlatform.LINUX_S390X: return TargetPlatform.LINUX_S390X;
+ 
+@@ -114,2 +116,5 @@ export function getTargetPlatform(platform: Platform | 'alpine', arch: string |
+ 			}
++			if (arch === 's390x') {
++				return TargetPlatform.LINUX_S390X;
++			}
+ 			return TargetPlatform.UNKNOWN;
+diff --git a/src/vs/platform/extensions/common/extensions.ts b/src/vs/platform/extensions/common/extensions.ts
+index 5973d4d..a7d6298 100644
+--- a/src/vs/platform/extensions/common/extensions.ts
++++ b/src/vs/platform/extensions/common/extensions.ts
+@@ -297,2 +297,3 @@ export const enum TargetPlatform {
+ 	LINUX_LOONG64 = 'linux-loong64',
++	LINUX_S390X = 'linux-s390x',
+ 
+diff --git a/package-lock.json b/package-lock.json
+index 7b02996..4642486 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -17875,10 +17875,11 @@
+       }
+     },
+     "node_modules/web-tree-sitter": {
+-      "version": "0.20.8",
+-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
+-      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
+-      "dev": true
++      "version": "0.23.0",
++      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.23.0.tgz",
++      "integrity": "sha512-p1T+ju2H30fpVX2q5yr+Wv/NfdMMWMjQp9Q+4eEPrHAJpPFh9DPfI2Yr9L1f5SA5KPE+g1cNUqPbpihxUDzmVw==",
++      "dev": true,
++      "license": "MIT"
+     },
+     "node_modules/webidl-conversions": {
+       "version": "3.0.1",
+diff --git a/package.json b/package.json
+index 7e0de18..4ceaded 100644
+--- a/package.json
++++ b/package.json
+@@ -226,7 +226,10 @@
+     },
+     "@parcel/watcher@2.1.0": {
+       "node-addon-api": "7.1.0"
++    },
++    "@vscode/l10n-dev@0.0.35": {
++      "web-tree-sitter": "0.23.0"
+     }
+   },
+   "repository": {
+     "type": "git",

--- a/patches/linux/reh/s390x/arch-4-s390x-package.json.patch
+++ b/patches/linux/reh/s390x/arch-4-s390x-package.json.patch
@@ -1,0 +1,35 @@
+diff --git a/package-lock.json b/package-lock.json
+index 7b02996..4642486 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -17875,10 +17875,11 @@
+       }
+     },
+     "node_modules/web-tree-sitter": {
+-      "version": "0.20.8",
+-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.8.tgz",
+-      "integrity": "sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==",
+-      "dev": true
++      "version": "0.23.0",
++      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.23.0.tgz",
++      "integrity": "sha512-p1T+ju2H30fpVX2q5yr+Wv/NfdMMWMjQp9Q+4eEPrHAJpPFh9DPfI2Yr9L1f5SA5KPE+g1cNUqPbpihxUDzmVw==",
++      "dev": true,
++      "license": "MIT"
+     },
+     "node_modules/webidl-conversions": {
+       "version": "3.0.1",
+diff --git a/package.json b/package.json
+index 7e0de18..4ceaded 100644
+--- a/package.json
++++ b/package.json
+@@ -226,7 +226,10 @@
+     },
+     "@parcel/watcher@2.1.0": {
+       "node-addon-api": "7.1.0"
++    },
++    "@vscode/l10n-dev@0.0.35": {
++      "web-tree-sitter": "0.23.0"
+     }
+   },
+   "repository": {
+     "type": "git",

--- a/patches/linux/yarn-dependencies.patch
+++ b/patches/linux/yarn-dependencies.patch
@@ -5,7 +5,7 @@ index 88e3c9e..4cad4f1 100644
 @@ -55,4 +55,6 @@ function npmInstall(dir, opts) {
  		opts.cwd = root;
 -		if (process.env['npm_config_arch'] === 'arm64') {
-+		if (process.env['npm_config_arch'] === 'arm64' || process.env['npm_config_arch'] === 'arm' || process.env['npm_config_arch'] === 'ppc64' || process.env['npm_config_arch'] === 'riscv64') {
++		if (process.env['npm_config_arch'] === 'arm64' || process.env['npm_config_arch'] === 'arm' || process.env['npm_config_arch'] === 'ppc64' || process.env['npm_config_arch'] === 'riscv64' || process.env['npm_config_arch'] === 's390x') {
  			run('sudo', ['docker', 'run', '--rm', '--privileged', 'multiarch/qemu-user-static', '--reset', '-p', 'yes'], opts);
 +		} else if (process.env['npm_config_arch'] === 'loong64') {
 +			run('sudo', ['docker', 'run', '--rm', '--privileged', 'loongcr.lcpu.dev/multiarch/archlinux', '--reset', '-p', 'yes'], opts);


### PR DESCRIPTION
This PR extends VSCodium by adding s390x (IBM Mainframe / System Z) to the list of valid targets for the remote extension host. 

This is mostly straightforward and very similar to the other supported architectures, with one difference that is required in the dependency tree of vscode, where web-tree-sitter needs to be updated to work around an endianness issue.

The CI components as used in this PR are currently still built in my forked version of vscode-linux-build-agent, but I have created a separate PR for that repository here: https://github.com/VSCodium/vscode-linux-build-agent/pull/24, if that is merged, then the paths used here can be updated accordingly.

I have been using a manually built and installed version of the REH for a few weeks now, and have not noticed any issues or regressions.