### PR TITLE
feat: loong64 support for client

### DIFF
--- a/.github/workflows/insider-linux.yml
+++ b/.github/workflows/insider-linux.yml
@@ -170,6 +170,10 @@ jobs:
           vscode_arch: riscv64
           npm_arch: riscv64
           image: vscodium/vscodium-linux-build-agent:focal-riscv64
+        - slug: LOONG64
+          vscode_arch: loong64
+          npm_arch: loong64
+          image: ghcr.io/darkyzhou/vscodium-linux-build-agent:trixie-loong64
     container:
       image: ${{ matrix.image }}
     env:

--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -169,6 +169,10 @@ jobs:
           vscode_arch: riscv64
           npm_arch: riscv64
           image: vscodium/vscodium-linux-build-agent:focal-riscv64
+        - slug: LOONG64
+          vscode_arch: loong64
+          npm_arch: loong64
+          image: ghcr.io/darkyzhou/vscodium-linux-build-agent:trixie-loong64
     container:
       image: ${{ matrix.image }}
     env:

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -431,7 +431,13 @@ elif [[ "${ASSETS}" != "null" ]]; then
         export SHOULD_BUILD_DEB="no"
         export SHOULD_BUILD_RPM="no"
         export SHOULD_BUILD_APPIMAGE="no"
-        export SHOULD_BUILD_TAR="no"
+
+        if [[ -z $( contains "${APP_NAME}-linux-loong64-${RELEASE_VERSION}.tar.gz" ) ]]; then
+          echo "Building on Linux Loong64 because we have no TAR"
+          export SHOULD_BUILD="yes"
+        else
+          export SHOULD_BUILD_TAR="no"
+        fi
 
         if [[ -z $( contains "${APP_NAME_LC}-reh-linux-loong64-${RELEASE_VERSION}.tar.gz" ) ]]; then
           echo "Building on Linux Loong64 because we have no REH archive"
@@ -599,7 +605,6 @@ else
     elif [[ "${VSCODE_ARCH}" == "loong64" ]]; then
       SHOULD_BUILD_DEB="no"
       SHOULD_BUILD_RPM="no"
-      SHOULD_BUILD_TAR="no"
     fi
     if [[ "${VSCODE_ARCH}" != "x64" || "${DISABLE_APPIMAGE}" == "yes" ]]; then
       export SHOULD_BUILD_APPIMAGE="no"

--- a/electron_linux_loong64.sh
+++ b/electron_linux_loong64.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+export ELECTRON_VERSION="32.2.5"
+export VSCODE_ELECTRON_TAG="v${ELECTRON_VERSION}"

--- a/electron_linux_loong64.sha256sums
+++ b/electron_linux_loong64.sha256sums
@@ -1,0 +1,1 @@
+8d8b540e36a62b778b0fb5e3798a2d47c2c0475925b78ff4a101aa864dfb28a9 *electron-v32.2.5-linux-loong64.zip

--- a/package_linux_bin.sh
+++ b/package_linux_bin.sh
@@ -13,6 +13,7 @@ chown -R root:root vscode
 
 cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
+export VSCODE_PLATFORM='linux'
 export VSCODE_SKIP_NODE_VERSION_CHECK=1
 export VSCODE_SYSROOT_PREFIX='-glibc-2.17'
 
@@ -26,6 +27,11 @@ elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   export USE_GNUPP2A=1
 elif [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
   export VSCODE_ELECTRON_REPOSITORY='riscv-forks/electron-riscv-releases'
+  export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+  export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+  export VSCODE_SKIP_SETUPENV=1
+elif [[ "${VSCODE_ARCH}" == "loong64" ]]; then
+  export VSCODE_ELECTRON_REPOSITORY='darkyzhou/electron-loong64'
   export ELECTRON_SKIP_BINARY_DOWNLOAD=1
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
   export VSCODE_SKIP_SETUPENV=1
@@ -113,6 +119,10 @@ done
 node build/azure-pipelines/distro/mixin-npm
 
 yarn gulp "vscode-linux-${VSCODE_ARCH}-min-ci"
+
+if [[ -f "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" ]]; then
+  bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" "../VSCode-linux-${VSCODE_ARCH}/resources/app/node_modules"
+fi
 
 find "../VSCode-linux-${VSCODE_ARCH}" -print0 | xargs -0 touch -c
 

--- a/package_linux_reh.sh
+++ b/package_linux_reh.sh
@@ -174,7 +174,7 @@ if [[ "${SHOULD_BUILD_REH}" != "no" ]]; then
   pushd "../vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
 
   if [[ -f "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" ]]; then
-    bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh"
+    bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" "node_modules"
   fi
 
   echo "Archiving REH"
@@ -193,7 +193,7 @@ if [[ "${SHOULD_BUILD_REH_WEB}" != "no" ]]; then
   pushd "../vscode-reh-web-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
 
   if [[ -f "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" ]]; then
-    bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh"
+    bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" "node_modules"
   fi
 
   echo "Archiving REH-web"

--- a/ripgrep_linux_loong64.sh
+++ b/ripgrep_linux_loong64.sh
@@ -1,7 +1,14 @@
+#!/usr/bin/env bash
+
 # When installing @vscode/ripgrep, it will try to download prebuilt ripgrep binary from https://github.com/microsoft/ripgrep-prebuilt,
 # however, loong64 is not a supported architecture and x86 will be picked as fallback, so we need to replace it with a native one.
 
-RG_PATH="node_modules/@vscode/ripgrep/bin/rg"
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <path_to_node_modules>"
+    exit 1
+fi
+
+RG_PATH="$1/@vscode/ripgrep/bin/rg"
 RG_VERSION="14.1.1"
 
 echo "Replacing ripgrep binary with loong64 one"


### PR DESCRIPTION
This PR introduces Loong64 support for client.

WIP: This PR uses `ghcr.io/darkyzhou/vscodium-linux-build-agent:trixie-loong64` as build image, which will be updated after https://github.com/VSCodium/vscode-linux-build-agent/pull/25 gets merged.

I will continue to maintain Loong64 support for VSCodium for at least the next six months. During this period, if any issues arise, please feel free to reach out to me. Additionally, I will be working on building a Loong64 VSCodium community to help maintain Electron and other dependencies.