### PR TITLE
Replace ripgrep binary for riscv64

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The minimal version is limited by the core component Electron, you may want to c
 - [x] GNU/Linux x64 (`deb`, `rpm`, `AppImage`, `snap`, `tar.gz`)
 - [x] GNU/Linux arm64 (`deb`, `rpm`, `snap`, `tar.gz`)
 - [x] GNU/Linux armhf (`deb`, `rpm`, `tar.gz`)
+- [x] GNU/Linux riscv64 (`tar.gz`)
 - [x] GNU/Linux loong64 (`tar.gz`)
 - [x] Windows 10 / Server 2012 R2 or newer x64
 - [x] Windows 10 / Server 2012 R2 or newer arm64

--- a/ripgrep_linux_riscv64.sh
+++ b/ripgrep_linux_riscv64.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# microsoft/ripgrep-prebuilt doesn't support riscv64.
+# Tracking PR: https://github.com/microsoft/ripgrep-prebuilt/pull/41
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <path_to_node_modules>"
+    exit 1
+fi
+
+RG_PATH="$1/@vscode/ripgrep/bin/rg"
+RG_VERSION="14.1.1-3"
+
+echo "Replacing ripgrep binary with riscv64 one"
+
+rm "${RG_PATH}"
+curl --silent --fail -L https://github.com/riscv-forks/ripgrep-riscv64-prebuilt/releases/download/${RG_VERSION}/rg -o "${RG_PATH}"
+chmod +x "${RG_PATH}"


### PR DESCRIPTION
Fix #2060

Microsoft doesn't respond to my PR https://github.com/microsoft/ripgrep-prebuilt/pull/41 after more than 3 weeks so I decided to host rg binaries for riscv64 in https://github.com/riscv-forks/ripgrep-riscv64-prebuilt .

And a minor fix about the documentation BTW.