### PR TITLE
ci(macos): use available runner

### DIFF
--- a/.github/workflows/insider-macos.yml
+++ b/.github/workflows/insider-macos.yml
@@ -40,9 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-12
+          - runner: macos-13
             vscode_arch: x64
-          # - runner: macos-14
           - runner: [self-hosted, macOS, ARM64]
             vscode_arch: arm64
 

--- a/.github/workflows/stable-macos.yml
+++ b/.github/workflows/stable-macos.yml
@@ -39,9 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-12
+          - runner: macos-13
             vscode_arch: x64
-          # - runner: macos-14
           - runner: [self-hosted, macOS, ARM64]
             vscode_arch: arm64
 


### PR DESCRIPTION
This PR upgrades to `macos-13` runner since the `macos-12` has been removed. 

References:
- https://github.com/actions/runner-images/issues/10721