### PR TITLE
ci: use jq for JSON parsing, avoid cut for querying version from tag

### DIFF
--- a/install_gh.sh
+++ b/install_gh.sh
@@ -4,9 +4,10 @@ set -ex
 
 GH_ARCH="amd64"
 
-VERSION=$( curl --retry 12 --retry-delay 30 "https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c2- )
+TAG=$( curl --retry 12 --retry-delay 30 "https://api.github.com/repos/cli/cli/releases/latest" | jq --raw-output '.tag_name' )
+VERSION=${TAG#v}
 
-curl --retry 12 --retry-delay 120 -sSL "https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${GH_ARCH}.tar.gz" -o "gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
+curl --retry 12 --retry-delay 120 -sSL "https://github.com/cli/cli/releases/download/${TAG}/gh_${VERSION}_linux_${GH_ARCH}.tar.gz" -o "gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
 
 tar xf "gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
 


### PR DESCRIPTION
Based on recent [job failure](https://github.com/VSCodium/vscodium/actions/runs/12436422943/job/34724736907), I think this should be more reliable; it is not good practice to use text parsing tools (grep, sed, and more) for JSON parsing.
Based on other scripts, `jq` is already used elsewhere so let’s use it there too.

Also use variables TAG and VERSION for readability.