### PR TITLE
Propose devcontainer environment and tasks

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -10,6 +10,7 @@ RUN apt update && \
         libxkbfile-dev \
         libsecret-1-dev \
         qemu-user \
+        shellcheck \
         && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+
+RUN apt update && \
+    DEBIAN_FRONTEND="noninteractive" \
+    apt install -y \
+        gcc-10 \
+        g++-10 \
+        libkrb5-dev \
+        libx11-dev \
+        libxkbfile-dev \
+        libsecret-1-dev \
+        qemu-user \
+        && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -6,7 +6,8 @@ Create a `.env` on the root of the project with the following content:
 # .env
 GH_TOKEN=your_github_token
 npm_config_arch=your_architecture # Options are: x64, arm64, arm, riscv64, loong64, ppc64, and s390x
-_VSCODE_ARCH=your_vsc_architecture # Options are: x64, arm64, armhf, riscv64, loong64, ppc64le, and s390x
+VSCODE_ARCH=your_vsc_architecture # Options are: x64, arm64, armhf, riscv64, loong64, ppc64le, and s390x
+#                                   note that VSC removes variables starting with VSCODE_ from the environment.
 # DISABLE_QEMU=true # Uncomment this if you prefer not to use the QEMU step in postinstall.js
 # Any other environment variable you want the tasks to run with or that set the build environment to your desired output architecture
 ```

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,6 +9,7 @@ npm_config_arch=your_architecture # Options are: x64, arm64, arm, riscv64, loong
 VSCODE_ARCH=your_vsc_architecture # Options are: x64, arm64, armhf, riscv64, loong64, ppc64le, and s390x
 #                                   note that VSC removes variables starting with VSCODE_ from the environment.
 # DISABLE_QEMU=true # Uncomment this if you prefer not to use the QEMU step in postinstall.js
+# DOCKER_DEFAULT_PLATFORM=linux/amd64 # Needed if building in something other than x64
 # Any other environment variable you want the tasks to run with or that set the build environment to your desired output architecture
 ```
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,13 @@
+# How To
+
+Create a `.env` on the root of the project with the following content:
+
+```bash
+# .env
+GH_TOKEN=your_github_token
+npm_config_arch=your_architecture # Options are: x64, arm64, arm, riscv64, loong64, ppc64, and s390x
+_VSCODE_ARCH=your_vsc_architecture # Options are: x64, arm64, armhf, riscv64, loong64, ppc64le, and s390x
+# Any other environment variable you want the tasks to run with or that set the build environment to your desired output architecture
+```
+
+Done, build your devcontainer and you are ready to go.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,6 +7,7 @@ Create a `.env` on the root of the project with the following content:
 GH_TOKEN=your_github_token
 npm_config_arch=your_architecture # Options are: x64, arm64, arm, riscv64, loong64, ppc64, and s390x
 _VSCODE_ARCH=your_vsc_architecture # Options are: x64, arm64, armhf, riscv64, loong64, ppc64le, and s390x
+# DISABLE_QEMU=true # Uncomment this if you prefer not to use the QEMU step in postinstall.js
 # Any other environment variable you want the tasks to run with or that set the build environment to your desired output architecture
 ```
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,22 +27,18 @@
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {
             "dockerDashComposeVersion": "none"
-        }
+        },
+        "ghcr.io/devcontainers-extra/features/shfmt:1": {}
     },
     // Uncomment if you have `sed` issues due to VirtFs
     // "mounts": [
     //     "type=volume,source=vscode-src,target=${containerWorkspaceFolder}/vscode"
     // ],
-    // These are better placed in the .env file
-    // "containerEnv": {
-    //     "npm_config_arch": "ppc64",
-    //     "_VSCODE_ARCH": "ppc64le"
-    // },
     "runArgs": [
         "--security-opt",
         "label=disable",
         "--env-file",
-        ".env" // a place to put your GH_TOKEN
+        "${localWorkspaceFolder}/.env"
     ],
     "capAdd": [
         "CAP_AUDIT_WRITE"
@@ -57,12 +53,19 @@
         // Configure properties specific to VS Code.
         "vscode": {
             // Set *default* container specific settings.json values on container create.
-            "settings": {},
+            "settings": {
+                "shellformat.path": "/usr/local/bin/shfmt",
+                "shellcheck.executablePath": "/usr/bin/shellcheck"
+            },
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
                 "dbaeumer.vscode-eslint",
                 "ms-azuretools.vscode-docker",
-                "github.vscode-github-actions"
+                "github.vscode-github-actions",
+                "foxundermoon.shell-format",
+                "rogalmic.bash-debug",
+                "mads-hartmann.bash-ide-vscode",
+                "timonwong.shellcheck"
             ]
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,71 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+    "name": "VSC Build Environment",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": {
+        "dockerfile": "Containerfile"
+    },
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "true"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "20.18.2"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "3.11"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "dockerDashComposeVersion": "none"
+        }
+    },
+    // Uncomment if you have `sed` issues due to VirtFs
+    // "mounts": [
+    //     "type=volume,source=vscode-src,target=${containerWorkspaceFolder}/vscode"
+    // ],
+    // These are better placed in the .env file
+    // "containerEnv": {
+    //     "npm_config_arch": "ppc64",
+    //     "_VSCODE_ARCH": "ppc64le"
+    // },
+    "runArgs": [
+        "--security-opt",
+        "label=disable",
+        "--env-file",
+        ".env" // a place to put your GH_TOKEN
+    ],
+    "capAdd": [
+        "CAP_AUDIT_WRITE"
+    ],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "yarn install",
+    "onCreateCommand": "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc", // you will also need the DISABLE_QEMU=true env var
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {},
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "ms-azuretools.vscode-docker",
+                "github.vscode-github-actions"
+            ]
+        }
+    },
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "vscode"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "type": "bashdb",
+            "request": "launch",
+            "name": "Bash-Debug (simplest configuration)",
+            "program": "${file}",
+            "args": [],
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
       {
         "label": "Download latest stable-linux vscode artifact",
         "type": "shell",
-        "command": "gh run list --workflow stable-linux --branch master --limit 1 | awk '{print $7}' | xargs -I {} gh run download {} -n vscode && sudo tar -xvzf vscode.tar.gz && sudo chown -R vscode:vscode ./vscode/",
+        "command": "set -a && source .env || true && set +a && gh run list --workflow stable-linux --branch master --limit 1 | awk '{print $7}' | xargs -I {} gh run download {} -n vscode && sudo tar -xvzf vscode.tar.gz && sudo chown -R vscode:vscode ./vscode/",
         "group": {
           "kind": "none"
         },
@@ -24,7 +24,7 @@
       {
         "label": "Build Linux REH",
         "type": "shell",
-        "command": "VSCODE_ARCH=\"${_VSCODE_ARCH}\" ./build/linux/package_reh.sh",
+        "command": "set -a && source .env || true && set +a && ./build/linux/package_reh.sh",
         "group": {
           "kind": "build",
           "isDefault": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,30 +4,54 @@
     "version": "2.0.0",
     "tasks": [
       {
-        "label": "Download latest stable-linux vscode artifact",
+        "label": "Download latest stable-linux vscode.tar.gz",
         "type": "shell",
-        "command": "set -a && source .env || true && set +a && gh run list --workflow stable-linux --branch master --limit 1 | awk '{print $7}' | xargs -I {} gh run download {} -n vscode && sudo tar -xvzf vscode.tar.gz && sudo chown -R vscode:vscode ./vscode/",
+        "command": "set -a && source .env || true && set +a && gh run list --workflow stable-linux --branch master -e workflow_dispatch --json databaseId --limit 1 --jq '.[].databaseId' | xargs -I {} gh run download {} -n vscode",
         "group": {
           "kind": "none"
         },
         "problemMatcher": []
       },
       {
-        "label": "Extract vscode.tar.gz",
-        "type": "shell",
-        "command": "sudo tar -xvzf vscode.tar.gz && sudo chown -R vscode:vscode ./vscode/",
-        "group": {
-          "kind": "none"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Build Linux REH",
+        "label": "Package REH",
         "type": "shell",
         "command": "set -a && source .env || true && set +a && ./build/linux/package_reh.sh",
         "group": {
           "kind": "build",
           "isDefault": false
+        },
+        "options": {
+          "env": {
+            "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION": "true",
+            "APP_NAME": "VSCodium",
+            "ASSETS_REPOSITORY": "VSCodium/VSCodium",
+            "BINARY_NAME": "codium",
+            "DISABLE_UPDATE": "yes",
+            "OS_NAME": "linux",
+            "VERSIONS_REPOSITORY": "VSCodium/versions",
+            "VSCODE_QUALITY": "stable"
+          }
+        }
+      },
+      {
+        "label": "Package BIN",
+        "type": "shell",
+        "command": "set -a && source .env || true && set +a && ./build/linux/package_bin.sh",
+        "group": {
+          "kind": "build",
+          "isDefault": false
+        },
+        "options": {
+          "env": {
+            "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION": "true",
+            "APP_NAME": "VSCodium",
+            "ASSETS_REPOSITORY": "VSCodium/VSCodium",
+            "BINARY_NAME": "codium",
+            "DISABLE_UPDATE": "yes",
+            "OS_NAME": "linux",
+            "VERSIONS_REPOSITORY": "VSCodium/versions",
+            "VSCODE_QUALITY": "stable"
+          }
         }
       }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Download latest stable-linux vscode artifact",
+        "type": "shell",
+        "command": "gh run list --workflow stable-linux --branch master --limit 1 | awk '{print $7}' | xargs -I {} gh run download {} -n vscode && sudo tar -xvzf vscode.tar.gz && sudo chown -R vscode:vscode ./vscode/",
+        "group": {
+          "kind": "none"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Extract vscode.tar.gz",
+        "type": "shell",
+        "command": "sudo tar -xvzf vscode.tar.gz && sudo chown -R vscode:vscode ./vscode/",
+        "group": {
+          "kind": "none"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Build Linux REH",
+        "type": "shell",
+        "command": "VSCODE_ARCH=\"${_VSCODE_ARCH}\" ./build/linux/package_reh.sh",
+        "group": {
+          "kind": "build",
+          "isDefault": false
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Bare-bones devcontainer and a few simple tasks to make it easier when debugging locally.

I was going to make the Containerfile more Power focused but I realized a lot could be left generic and changed using a `.env`. 

The tasks are just enough to build REH:
- `Download latest stable-linux vscode artifact`: Downloads and extracts the latest vscode.tar.gz from stable-linux master (Hopefully that is available at the time someone wants to run this task and it hasn't expired)
- `Extract vscode.tar.gz`: If the `vscode.tar.gz` is already present, just extract it and change the ownership
- `Build Linux REH`: Run the `./build/linux/package_reh.sh`

Hopefully this helps others.