### PR TITLE
feat: new version number

### DIFF
--- a/get_repo.sh
+++ b/get_repo.sh
@@ -27,16 +27,16 @@ if [[ -z "${RELEASE_VERSION}" ]]; then
     fi
   fi
 
-  date=$( date +%Y%j )
+  TIME_PATCH=$(($(date +%-j) * 24 + $(date +%-H)))
 
   if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
-    RELEASE_VERSION="${MS_TAG}.${date: -5}-insider"
+    RELEASE_VERSION="${MS_TAG}${TIME_PATCH}-insider"
   else
-    RELEASE_VERSION="${MS_TAG}.${date: -5}"
+    RELEASE_VERSION="${MS_TAG}${TIME_PATCH}"
   fi
 else
   if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
-    if [[ "${RELEASE_VERSION}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+-insider$ ]];
+    if [[ "${RELEASE_VERSION}" =~ ^([0-9]+\.[0-9]+\.[0-5])[0-9]+-insider$ ]];
     then
       MS_TAG="${BASH_REMATCH[1]}"
     else
@@ -44,7 +44,7 @@ else
       exit 1
     fi
   else
-    if [[ "${RELEASE_VERSION}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+$ ]];
+    if [[ "${RELEASE_VERSION}" =~ ^([0-9]+\.[0-9]+\.[0-5])[0-9]+$ ]];
     then
       MS_TAG="${BASH_REMATCH[1]}"
     else

--- a/patches/insider/add-remote-url.patch
+++ b/patches/insider/add-remote-url.patch
@@ -1,18 +1,18 @@
 diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
-index 7d58861..cefb8ad 100644
+index c1d64c0..3e60e80 100644
 --- a/build/gulpfile.reh.js
 +++ b/build/gulpfile.reh.js
-@@ -306,3 +306,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
+@@ -321,3 +321,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
  		const productJsonStream = gulp.src(['product.json'], { base: '.' })
--			.pipe(json({ commit, date: readISODate('out-build'), version, release }))
-+			.pipe(json({ commit, date: readISODate('out-build'), version, release, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/${version}.${release}-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}.${release}-insider.tar.gz' }))
+-			.pipe(json({ commit, date: readISODate('out-build'), version }))
++			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/${version}-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}-insider.tar.gz' }))
  			.pipe(es.through(function (file) {
 diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
-index 4af4067..1bac2cc 100644
+index 7046ee0..9aa7bb0 100644
 --- a/build/gulpfile.vscode.js
 +++ b/build/gulpfile.vscode.js
-@@ -261,3 +261,3 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
+@@ -288,3 +288,3 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
  		const productJsonStream = gulp.src(['product.json'], { base: '.' })
--			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, release }))
-+			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, release, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/${version}.${release}-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}.${release}-insider.tar.gz' }))
+-			.pipe(json({ commit, date: readISODate('out-build'), checksums, version }))
++			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/${version}-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}-insider.tar.gz' }))
  			.pipe(es.through(function (file) {

--- a/patches/version-0-release.patch
+++ b/patches/version-0-release.patch
@@ -1,43 +1,5 @@
-diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
-index c1d64c0..5daeb3d 100644
---- a/build/gulpfile.reh.js
-+++ b/build/gulpfile.reh.js
-@@ -310,2 +310,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
- 		const name = product.nameShort;
-+		const release = packageJson.release;
- 
-@@ -313,3 +314,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
- 		const packageJsonStream = gulp.src(['remote/package.json'], { base: 'remote' })
--			.pipe(json({ name, version, dependencies: undefined, optionalDependencies: undefined, type: 'module' }))
-+			.pipe(json({ name, version, release, dependencies: undefined, optionalDependencies: undefined, type: 'module' }))
- 			.pipe(es.through(function (file) {
-@@ -321,3 +322,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
- 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
--			.pipe(json({ commit, date: readISODate('out-build'), version }))
-+			.pipe(json({ commit, date: readISODate('out-build'), version, release }))
- 			.pipe(es.through(function (file) {
-diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
-index 7046ee0..6500cb9 100644
---- a/build/gulpfile.vscode.js
-+++ b/build/gulpfile.vscode.js
-@@ -264,3 +264,3 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
- 
--		let version = packageJson.version;
-+		let version = packageJson.version
- 		const quality = product.quality;
-@@ -272,3 +272,4 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
- 		const name = product.nameShort;
--		const packageJsonUpdates = { name, version };
-+		const release = packageJson.release;
-+		const packageJsonUpdates = { name, version, release };
- 
-@@ -288,3 +289,3 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
- 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
--			.pipe(json({ commit, date: readISODate('out-build'), checksums, version }))
-+			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, release }))
- 			.pipe(es.through(function (file) {
 diff --git a/build/gulpfile.vscode.linux.js b/build/gulpfile.vscode.linux.js
-index cd8610d..0fd7083 100644
+index cd8610d..2d928b1 100644
 --- a/build/gulpfile.vscode.linux.js
 +++ b/build/gulpfile.vscode.linux.js
 @@ -27,4 +27,2 @@ const commit = getVersion(root);
@@ -48,113 +10,14 @@ index cd8610d..0fd7083 100644
 @@ -90,3 +88,3 @@ function prepareDebPackage(arch) {
  					.pipe(replace('@@NAME@@', product.applicationName))
 -					.pipe(replace('@@VERSION@@', packageJson.version + '-' + linuxPackageRevision))
-+					.pipe(replace('@@VERSION@@', `${packageJson.version}.${packageJson.release}`))
++					.pipe(replace('@@VERSION@@', packageJson.version))
  					.pipe(replace('@@ARCHITECTURE@@', debArch))
-@@ -203,4 +201,3 @@ function prepareRpmPackage(arch) {
- 			.pipe(replace('@@ICON@@', product.linuxIconName))
--			.pipe(replace('@@VERSION@@', packageJson.version))
+@@ -204,3 +202,2 @@ function prepareRpmPackage(arch) {
+ 			.pipe(replace('@@VERSION@@', packageJson.version))
 -			.pipe(replace('@@RELEASE@@', linuxPackageRevision))
-+			.pipe(replace('@@VERSION@@', `${packageJson.version}.${packageJson.release}`))
  			.pipe(replace('@@ARCHITECTURE@@', rpmArch))
 @@ -278,3 +275,3 @@ function prepareSnapPackage(arch) {
  			.pipe(replace('@@NAME@@', product.applicationName))
 -			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
-+			.pipe(replace('@@VERSION@@', `${packageJson.version}.${packageJson.release}`))
++			.pipe(replace('@@VERSION@@', packageJson.version))
  			// Possible run-on values https://snapcraft.io/docs/architectures
-diff --git a/build/gulpfile.vscode.win32.js b/build/gulpfile.vscode.win32.js
-index 98175f5..afacbe3 100644
---- a/build/gulpfile.vscode.win32.js
-+++ b/build/gulpfile.vscode.win32.js
-@@ -89,4 +89,4 @@ function buildWin32Setup(arch, target) {
- 			DirName: product.win32DirName,
--			Version: pkg.version,
--			RawVersion: pkg.version.replace(/-\w+$/, ''),
-+			Version: `${pkg.version}.${pkg.release}`,
-+			RawVersion: `${pkg.version.replace(/-\w+$/, '')}.${pkg.release}`,
- 			NameVersion: product.win32NameVersion + (target === 'user' ? ' (User)' : ''),
-diff --git a/src/vs/base/common/product.ts b/src/vs/base/common/product.ts
-index d700431..076cc84 100644
---- a/src/vs/base/common/product.ts
-+++ b/src/vs/base/common/product.ts
-@@ -59,2 +59,3 @@ export interface IProductConfiguration {
- 	readonly version: string;
-+	readonly release: string;
- 	readonly date?: string;
-diff --git a/src/vs/platform/diagnostics/node/diagnosticsService.ts b/src/vs/platform/diagnostics/node/diagnosticsService.ts
-index e523217..b00ccb4 100644
---- a/src/vs/platform/diagnostics/node/diagnosticsService.ts
-+++ b/src/vs/platform/diagnostics/node/diagnosticsService.ts
-@@ -233,3 +233,3 @@ export class DiagnosticsService implements IDiagnosticsService {
- 		const output: string[] = [];
--		output.push(`Version:          ${this.productService.nameShort} ${this.productService.version} (${this.productService.commit || 'Commit unknown'}, ${this.productService.date || 'Date unknown'})`);
-+		output.push(`Version:          ${this.productService.nameShort} ${this.productService.version} ${this.productService.release || 'Release unknown'} (${this.productService.commit || 'Commit unknown'}, ${this.productService.date || 'Date unknown'})`);
- 		output.push(`OS Version:       ${osLib.type()} ${osLib.arch()} ${osLib.release()}`);
-diff --git a/src/vs/platform/product/common/product.ts b/src/vs/platform/product/common/product.ts
-index d27cdce..17ac262 100644
---- a/src/vs/platform/product/common/product.ts
-+++ b/src/vs/platform/product/common/product.ts
-@@ -45,6 +45,7 @@ else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
- 	if (!product.version) {
--		const pkg = globalThis._VSCODE_PACKAGE_JSON as { version: string };
-+		const pkg = globalThis._VSCODE_PACKAGE_JSON as { version: string, release: string };
- 
- 		Object.assign(product, {
--			version: pkg.version
-+			version: pkg.version,
-+			release: pkg.release
- 		});
-diff --git a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-index ac461ef..1258f27 100644
---- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-@@ -20,2 +20,3 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
- import { createWorkbenchDialogOptions } from '../../../../platform/dialogs/browser/dialog.js';
-+import { getReleaseString } from '../../../../workbench/common/release.js';
- 
-@@ -80,2 +81,4 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
- 		const detailString = (useAgo: boolean): string => {
-+			const releaseString = getReleaseString();
-+
- 			return localize('aboutDetail',
-@@ -86,3 +89,3 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
- 				navigator.userAgent
--			);
-+			).replace('\n', `\n${releaseString} ${this.productService.release || 'Unknown'}\n`);
- 		};
-diff --git a/src/vs/workbench/common/release.ts b/src/vs/workbench/common/release.ts
-new file mode 100644
-index 0000000..82dbe6a
---- /dev/null
-+++ b/src/vs/workbench/common/release.ts
-@@ -0,0 +1,14 @@
-+import { language } from '../../base/common/platform.js';
-+
-+const DEFAULT_LABEL = 'Release:';
-+const LABELS: { [key: string]: string } = {
-+	'en': DEFAULT_LABEL,
-+	'fr': 'Révision :',
-+	'ru': 'Релиз:',
-+	'zh-hans': '发布版本:',
-+	'zh-hant': '發布版本:',
-+};
-+
-+export function getReleaseString(): string {
-+	return LABELS[language] ?? DEFAULT_LABEL;
-+}
-diff --git a/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts b/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
-index 6c61a59..d58f8fc 100644
---- a/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
-+++ b/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
-@@ -15,2 +15,3 @@ import { process } from '../../../../base/parts/sandbox/electron-sandbox/globals
- import { getActiveWindow } from '../../../../base/browser/dom.js';
-+import { getReleaseString } from '../../../../workbench/common/release.js';
- 
-@@ -80,2 +81,3 @@ export class NativeDialogHandler extends AbstractDialogHandler {
- 		const osProps = await this.nativeHostService.getOSProperties();
-+		const releaseString = getReleaseString();
- 
-@@ -93,3 +95,3 @@ export class NativeDialogHandler extends AbstractDialogHandler {
- 				`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`
--			);
-+			).replace('\n', `\n${releaseString} ${this.productService.release || 'Unknown'}\n`);
- 		};

--- a/patches/version-1-update.patch
+++ b/patches/version-1-update.patch
@@ -67,7 +67,7 @@ index a1ec3fe..f954720 100644
 +	}
  }
 diff --git a/src/vs/platform/update/electron-main/updateService.darwin.ts b/src/vs/platform/update/electron-main/updateService.darwin.ts
-index 57398fb..8e36930 100644
+index 57398fb..5f331ba 100644
 --- a/src/vs/platform/update/electron-main/updateService.darwin.ts
 +++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
 @@ -15,3 +15,3 @@ import { ILogService } from '../../log/common/log.js';
@@ -91,7 +91,7 @@ index 57398fb..8e36930 100644
 -		const url = createUpdateURL(assetID, quality, this.productService);
 +		const url = createUpdateURL(this.productService, quality, process.platform, process.arch);
  		try {
-@@ -94,4 +90,29 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
+@@ -94,4 +90,26 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
  	protected doCheckForUpdates(context: any): void {
 +		if (!this.url) {
 +			return;
@@ -109,10 +109,7 @@ index 57398fb..8e36930 100644
 +					return Promise.resolve(null);
 +				}
 +
-+				const fetchedVersion = update.productVersion.replace(/(\d+\.\d+\.\d+)(?:\.(\d+))(\-\w+)?/, '$1$3+$2');
-+				const currentVersion = `${this.productService.version}+${this.productService.release}`;
-+
-+				if(semver.compareBuild(currentVersion, fetchedVersion) >= 0) {
++				if(semver.compareBuild(this.productService.version, update.productVersion) >= 0) {
 +					this.setState(State.Idle(UpdateType.Setup));
 +				}
 +				else {
@@ -132,7 +129,7 @@ index dd18900..920dc10 100644
 +		return createUpdateURL(this.productService, quality, process.platform, process.arch);
  	}
 diff --git a/src/vs/platform/update/electron-main/updateService.win32.ts b/src/vs/platform/update/electron-main/updateService.win32.ts
-index db92de2..06981b3 100644
+index db92de2..cfed728 100644
 --- a/src/vs/platform/update/electron-main/updateService.win32.ts
 +++ b/src/vs/platform/update/electron-main/updateService.win32.ts
 @@ -11,3 +11,2 @@ import { CancellationToken } from '../../../base/common/cancellation.js';
@@ -193,27 +190,24 @@ index db92de2..06981b3 100644
 -		return createUpdateURL(platform, quality, this.productService);
 +		return createUpdateURL(this.productService, quality, process.platform, process.arch, target);
  	}
-@@ -130,2 +145,10 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -130,2 +145,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
-+				const fetchedVersion = update.productVersion.replace(/(\d+\.\d+\.\d+)(?:\.(\d+))(\-\w+)?/, '$1$3+$2');
-+				const currentVersion = `${this.productService.version}+${this.productService.release}`;
-+
-+				if(semver.compareBuild(currentVersion, fetchedVersion) >= 0) {
++				if(semver.compareBuild(this.productService.version, update.productVersion) >= 0) {
 +					this.setState(State.Idle(updateType));
 +					return Promise.resolve(null);
 +				}
 +
  				if (updateType === UpdateType.Archive) {
-@@ -156,3 +179,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -156,3 +176,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
 -						const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
 +						const fastUpdatesEnabled = getUpdateType() == UpdateType.Setup && this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
  						if (fastUpdatesEnabled) {
-@@ -168,3 +191,2 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -168,3 +188,2 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  			.then(undefined, err => {
 -				this.telemetryService.publicLog2<{ messageHash: string }, UpdateErrorClassification>('update:error', { messageHash: String(hash(String(err))) });
  				this.logService.error(err);
-@@ -252,6 +274,14 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -252,6 +271,14 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  		} else {
 -			spawn(this.availableUpdate.packagePath, ['/silent', '/log', '/mergetasks=runcode,!desktopicon,!quicklaunchicon'], {
 -				detached: true,

--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -191,8 +191,7 @@ cat product.json
 # package.json
 cp package.json{,.bak}
 
-setpath "package" "version" "$( echo "${RELEASE_VERSION}" | sed -n -E "s/^(.*)\.([0-9]+)(-insider)?$/\1/p" )"
-setpath "package" "release" "$( echo "${RELEASE_VERSION}" | sed -n -E "s/^(.*)\.([0-9]+)(-insider)?$/\2/p" )"
+setpath "package" "version" "${RELEASE_VERSION%-insider}"
 
 replace 's|Microsoft Corporation|VSCodium|' package.json
 


### PR DESCRIPTION
The new version number use the standard `MAJOR.MINOR.PATCH`.
But our patch number will be constructed as: `<VSCode's patch number><time based between 0 and 9999>`

VSCode has never released more than 5 patches so the max patch number is 5 so we can keep our patch number under 65,535.

It will solve:
- `.msi` only supports the first 3 numbers when updating. 
- allow us to have several releases on the same day. Don't have to wait for the next day for deploying a hotfix...