### PR TITLE
fix: remove leading zeros before passing version to extension

### DIFF
--- a/patches/version-0-release.patch
+++ b/patches/version-0-release.patch
@@ -21,3 +21,12 @@ index cd8610d..2d928b1 100644
 -			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
 +			.pipe(replace('@@VERSION@@', packageJson.version))
  			// Possible run-on values https://snapcraft.io/docs/architectures
+diff --git a/src/vs/workbench/api/common/extHost.api.impl.ts b/src/vs/workbench/api/common/extHost.api.impl.ts
+index f13affa..60f0ccb 100644
+--- a/src/vs/workbench/api/common/extHost.api.impl.ts
++++ b/src/vs/workbench/api/common/extHost.api.impl.ts
+@@ -1548,3 +1548,3 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
+ 		return <typeof vscode>{
+-			version: initData.version,
++			version: initData.version.replace(/\.0+/g, '.'),
+ 			// namespaces


### PR DESCRIPTION
This PR removes the leading zeros in the patch number of the version number.

Reference:
- #2301