### PR TITLE
fix: hard code version in server template

### DIFF
--- a/patches/add-remote-url.patch
+++ b/patches/add-remote-url.patch
@@ -5,7 +5,7 @@ index c1d64c0..3e60e80 100644
 @@ -321,3 +321,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
  		const productJsonStream = gulp.src(['product.json'], { base: '.' })
 -			.pipe(json({ commit, date: readISODate('out-build'), version }))
-+			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/${version/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}.tar.gz' }))
++			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/!!RELEASE_VERSION!!/!!APP_NAME_LC!!-reh-${os}-${arch}-!!RELEASE_VERSION!!.tar.gz' }))
  			.pipe(es.through(function (file) {
 diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
 index 7046ee0..9aa7bb0 100644
@@ -14,5 +14,5 @@ index 7046ee0..9aa7bb0 100644
 @@ -288,3 +288,3 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
  		const productJsonStream = gulp.src(['product.json'], { base: '.' })
 -			.pipe(json({ commit, date: readISODate('out-build'), checksums, version }))
-+			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/${version}/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}.tar.gz' }))
++			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/!!RELEASE_VERSION!!/!!APP_NAME_LC!!-reh-${os}-${arch}-!!RELEASE_VERSION!!.tar.gz' }))
  			.pipe(es.through(function (file) {

--- a/patches/insider/add-remote-url.patch
+++ b/patches/insider/add-remote-url.patch
@@ -4,8 +4,8 @@ index 2606eed..3e60e80 100644
 +++ b/build/gulpfile.reh.js
 @@ -321,3 +321,3 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
  		const productJsonStream = gulp.src(['product.json'], { base: '.' })
--			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/${version/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}.tar.gz' }))
-+			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/${version}-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}-insider.tar.gz' }))
+-			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/!!RELEASE_VERSION!!/!!APP_NAME_LC!!-reh-${os}-${arch}-!!RELEASE_VERSION!!.tar.gz' }))
++			.pipe(json({ commit, date: readISODate('out-build'), version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/!!RELEASE_VERSION!!-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-!!RELEASE_VERSION!!-insider.tar.gz' }))
  			.pipe(es.through(function (file) {
 diff --git a/build/gulpfile.vscode.js b/build/gulpfile.vscode.js
 index b975c64..9aa7bb0 100644
@@ -13,6 +13,6 @@ index b975c64..9aa7bb0 100644
 +++ b/build/gulpfile.vscode.js
 @@ -288,3 +288,3 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
  		const productJsonStream = gulp.src(['product.json'], { base: '.' })
--			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/${version}/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}.tar.gz' }))
-+			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/${version}-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-${version}-insider.tar.gz' }))
+-			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!/releases/download/!!RELEASE_VERSION!!/!!APP_NAME_LC!!-reh-${os}-${arch}-!!RELEASE_VERSION!!.tar.gz' }))
++			.pipe(json({ commit, date: readISODate('out-build'), checksums, version, serverDownloadUrlTemplate: 'https://github.com/!!GH_REPO_PATH!!-insiders/releases/download/!!RELEASE_VERSION!!-insider/!!APP_NAME_LC!!-reh-${os}-${arch}-!!RELEASE_VERSION!!-insider.tar.gz' }))
  			.pipe(es.through(function (file) {

--- a/utils.sh
+++ b/utils.sh
@@ -21,6 +21,7 @@ apply_patch() {
   replace "s|!!BINARY_NAME!!|${BINARY_NAME}|g" "$1"
   replace "s|!!GH_REPO_PATH!!|${GH_REPO_PATH}|g" "$1"
   replace "s|!!ORG_NAME!!|${ORG_NAME}|g" "$1"
+  replace "s|!!RELEASE_VERSION!!|${RELEASE_VERSION}|g" "$1"
 
   if ! git apply --ignore-whitespace "$1"; then
     echo failed to apply patch "$1" >&2


### PR DESCRIPTION
Now, the extension has the version without the leading zero so the generated url isn't correct.
And `}` was missing.

Hard coding the version fix the issue.

References:
- #2303