### PR TITLE
fix(reh): use correct ripgrep.sh path

### DIFF
--- a/build/linux/package_reh.sh
+++ b/build/linux/package_reh.sh
@@ -171,8 +171,8 @@ if [[ "${SHOULD_BUILD_REH}" != "no" ]]; then
 
   pushd "../vscode-reh-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
 
-  if [[ -f "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" ]]; then
-    bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" "node_modules"
+  if [[ -f "../build/linux/${VSCODE_ARCH}/ripgrep.sh" ]]; then
+    bash "../build/linux/${VSCODE_ARCH}/ripgrep.sh" "node_modules"
   fi
 
   echo "Archiving REH"
@@ -190,8 +190,8 @@ if [[ "${SHOULD_BUILD_REH_WEB}" != "no" ]]; then
 
   pushd "../vscode-reh-web-${VSCODE_PLATFORM}-${VSCODE_ARCH}"
 
-  if [[ -f "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" ]]; then
-    bash "../ripgrep_${VSCODE_PLATFORM}_${VSCODE_ARCH}.sh" "node_modules"
+  if [[ -f "../build/linux/${VSCODE_ARCH}/ripgrep.sh" ]]; then
+    bash "../build/linux/${VSCODE_ARCH}/ripgrep.sh" "node_modules"
   fi
 
   echo "Archiving REH-web"


### PR DESCRIPTION
This PR fixes the incorrect `ripgrep.sh` path specified in `package_reh.sh`, causing `rg` binary of REH server not being replaced with native ones.