### PR TITLE
fix(riscv): lower glibc version to 2.31 for ripgrep

### DIFF
--- a/build/linux/riscv64/ripgrep.sh
+++ b/build/linux/riscv64/ripgrep.sh
@@ -9,7 +9,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 RG_PATH="$1/@vscode/ripgrep/bin/rg"
-RG_VERSION="14.1.1-3"
+RG_VERSION="14.1.1-4"
 
 echo "Replacing ripgrep binary with riscv64 one"
 


### PR DESCRIPTION
https://github.com/riscv-forks/ripgrep-riscv64-prebuilt/issues/1