### PR TITLE
feat(fix-npm-postinstall): use tonistiigi/binfmt:latest for loong64

### DIFF
--- a/patches/linux/fix-npm-postinstall.patch
+++ b/patches/linux/fix-npm-postinstall.patch
@@ -1,15 +1,16 @@
 diff --git a/build/npm/postinstall.js b/build/npm/postinstall.js
-index fa8da7d..abd8957 100644
+index fa8da7d..5e2f51b 100644
 --- a/build/npm/postinstall.js
 +++ b/build/npm/postinstall.js
-@@ -55,5 +55,7 @@ function npmInstall(dir, opts) {
+@@ -53,8 +53,9 @@ function npmInstall(dir, opts) {
+ 		log(dir, `Installing dependencies inside container ${process.env['VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME']}...`);
+ 
  		opts.cwd = root;
 -		if (process.env['npm_config_arch'] === 'arm64') {
 -			run('sudo', ['docker', 'run', '--rm', '--privileged', 'multiarch/qemu-user-static', '--reset', '-p', 'yes'], opts);
--		}
-+		if ((process.env['npm_config_arch'] === 'arm64' || process.env['npm_config_arch'] === 'arm' || process.env['npm_config_arch'] === 'ppc64' || process.env['npm_config_arch'] === 'riscv64' || process.env['npm_config_arch'] === 's390x') && process.env['DISABLE_QEMU'] !== 'true') {
++		const emulateArchList = ['arm64', 'arm', 'ppc64', 'riscv64', 's390x', 'loong64'];
++		if (process.env['DISABLE_QEMU'] !== 'true' && !!process.env['npm_config_arch'] && emulateArchList.includes(process.env['npm_config_arch'])) {
 +			run('sudo', ['docker', 'run', '--rm', '--privileged', 'tonistiigi/binfmt:latest', '--install', 'all'], opts);
-+		} else if (process.env['npm_config_arch'] === 'loong64') {
-+			run('sudo', ['docker', 'run', '--rm', '--privileged', 'loongcr.lcpu.dev/multiarch/archlinux', '--reset', '-p', 'yes'], opts);
-+ 		}
+ 		}
  		run('sudo', [
+ 			'docker', 'run',


### PR DESCRIPTION
It turns out [`tonistiigi/binfmt` already supports `loong64`](https://github.com/tonistiigi/binfmt/blob/69294ec00cc321906218d3e6229204e94d924ff4/cmd/binfmt/config.go#L69), so I think we no longer need `loongcr.lcpu.dev/multiarch/archlinux` for `fix-npm-postinstall.patch`