### PR TITLE
Update Node.js version in build documentation

### DIFF
--- a/docs/howto-build.md
+++ b/docs/howto-build.md
@@ -17,7 +17,7 @@
 
 ## <a id="dependencies"></a>Dependencies
 
-- node 20.18
+- node 22.21.1
 - jq
 - git
 - python3 3.11

--- a/docs/howto-build.md
+++ b/docs/howto-build.md
@@ -17,7 +17,7 @@
 
 ## <a id="dependencies"></a>Dependencies
 
-- node 22.21.1
+- node (check [.nvmrc](../.nvmrc) for version)
 - jq
 - git
 - python3 3.11


### PR DESCRIPTION
Slight discrepency in the docs, that needs updating. I ran into an issue with node 20, due to the increased use of ts, i was getting unknown filetype error, and then i found that the nvmrc had been updated since i last built this.