### PR TITLE
Use vscode sysroot prefix -glibc-2.28 for ppc64le

### DIFF
--- a/build/linux/package_bin.sh
+++ b/build/linux/package_bin.sh
@@ -26,6 +26,7 @@ if [[ "${VSCODE_ARCH}" == "arm64" || "${VSCODE_ARCH}" == "armhf" ]]; then
 elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   export VSCODE_SYSROOT_REPOSITORY='VSCodium/vscode-linux-build-agent'
   export VSCODE_SYSROOT_VERSION='20240129-253798'
+  export VSCODE_SYSROOT_PREFIX="-glibc-2.28"
   export ELECTRON_SKIP_BINARY_DOWNLOAD=1
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
   export VSCODE_SKIP_SETUPENV=1

--- a/build/linux/prepare_assets.sh
+++ b/build/linux/prepare_assets.sh
@@ -2,6 +2,18 @@
 
 cd vscode || { echo "'vscode' dir not found"; exit 1; }
 
+if [[ -z "${VSCODE_SYSROOT_REPOSITORY}" ]]; then
+  unset VSCODE_SYSROOT_REPOSITORY
+fi
+
+if [[ -z "${VSCODE_SYSROOT_VERSION}" ]]; then
+  unset VSCODE_SYSROOT_VERSION
+fi
+
+if [[ -z "${VSCODE_SYSROOT_PREFIX}" ]]; then
+  unset VSCODE_SYSROOT_PREFIX
+fi
+
 if [[ "${SHOULD_BUILD_APPIMAGE}" != "no" && "${VSCODE_ARCH}" != "x64" ]]; then
   SHOULD_BUILD_APPIMAGE="no"
 fi


### PR DESCRIPTION
Well that was closer
https://github.com/VSCodium/vscode-linux-build-agent/releases/tag/v20240129-253798
https://github.com/VSCodium/vscodium/actions/runs/24251079261/job/70812116375
Looks like prepare assets was looking for `powerpc64le-linux-gnu-glibc-2.28-gcc-10.5.0.tar.gz` but the actual release only has `powerpc64le-linux-gnu-glibc-2.28.tar.gz`