### PR TITLE
Fixed arguments on appimage

### DIFF
--- a/build/linux/appimage/recipe.yml
+++ b/build/linux/appimage/recipe.yml
@@ -40,6 +40,11 @@ script:
   - export PERLLIB="${HERE}"/usr/share/perl5/:"${HERE}"/usr/lib/perl5/:"${PERLLIB}"
   - export GSETTINGS_SCHEMA_DIR="${HERE}"/usr/share/glib-2.0/schemas/:"${GSETTINGS_SCHEMA_DIR}"
   - export QT_PLUGIN_PATH="${HERE}"/usr/lib/qt4/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib32/qt4/plugins/:"${HERE}"/usr/lib64/qt4/plugins/:"${HERE}"/usr/lib/qt5/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib32/qt5/plugins/:"${HERE}"/usr/lib64/qt5/plugins/:"${QT_PLUGIN_PATH}"
-  - EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2- | sed -e 's|%.||g')
-  - exec ${EXEC} "$@"
+  - EXEC="${HERE}/usr/share/@@APPNAME@@/@@APPNAME@@"
+  - EXEC_CLI="${HERE}/usr/share/@@APPNAME@@/bin/@@APPNAME@@"
+  - if [ "$1" = "--" ]; then
+  -   shift
+  -   exec "${EXEC_CLI}" "$@"
+  - fi
+  - exec "${EXEC}" "$@"
   - EOF

--- a/build/linux/appimage/recipe.yml
+++ b/build/linux/appimage/recipe.yml
@@ -36,7 +36,6 @@ script:
   - #!/bin/sh
   - HERE="$(dirname "$(readlink -f "${0}")")"
   - export PATH="${HERE}"/usr/bin/:"${HERE}"/usr/sbin/:"${HERE}"/usr/games/:"${HERE}"/bin/:"${HERE}"/sbin/:"${PATH}"
-  - export LD_LIBRARY_PATH="${HERE}"/usr/lib/:"${HERE}"/usr/lib32/:"${HERE}"/usr/lib64/:"${HERE}"/lib/:"${HERE}"/lib/i386-linux-gnu/:"${HERE}"/lib/x86_64-linux-gnu/:"${HERE}"/lib32/:"${HERE}"/lib64/:"${LD_LIBRARY_PATH}"
   - export XDG_DATA_DIRS="${HERE}"/usr/share/:"${XDG_DATA_DIRS}"
   - export PERLLIB="${HERE}"/usr/share/perl5/:"${HERE}"/usr/lib/perl5/:"${PERLLIB}"
   - export GSETTINGS_SCHEMA_DIR="${HERE}"/usr/share/glib-2.0/schemas/:"${GSETTINGS_SCHEMA_DIR}"


### PR DESCRIPTION


When doing commands such as below, it opens an instance of codium instead of listing active extensions in cli or installing extensions. 
```
vscodium.AppImage --list-extensions

vscodium.AppImage --install-extension

```

This PR fixes that by using a simpler approach rather than adjusting for each possible command. The following syntax will properly work and installing extensions are also properly working even with a custom --extensions-dir
```
vscodium.AppImage -- --list-extensions
vscodium.AppImage -- --install-extension
```

For running the app normally  you can still use the following

```
vscodium.AppImage

vscodium.AppImage --user-data-dir /home/user/mycustomdata  --extensions-dir /home/user/mycustomextension
```
