### PR TITLE
Fixed arguments on appimage

### DIFF
--- a/build/linux/appimage/build.sh
+++ b/build/linux/appimage/build.sh
@@ -33,13 +33,11 @@ if [[ "${VSCODE_ARCH}" == "x64" ]]; then
   APP_NAME_LC="$( echo "${APP_NAME}" | awk '{print tolower($0)}' )"
 
   if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
-    sed -i "s|@@NAME@@|${APP_NAME}-Insiders|g" recipe.yml
-    sed -i "s|@@APPNAME@@|${BINARY_NAME}|g" recipe.yml
+    sed -i "s|@@APP_NAME@@|${APP_NAME}-Insiders|g" recipe.yml
     sed -i "s|@@BINARY_NAME@@|${BINARY_NAME}|g" recipe.yml
     sed -i "s|@@ICON@@|${APP_NAME_LC}-insiders|g" recipe.yml
   else
-    sed -i "s|@@NAME@@|${APP_NAME}|g" recipe.yml
-    sed -i "s|@@APPNAME@@|${BINARY_NAME}|g" recipe.yml
+    sed -i "s|@@APP_NAME@@|${APP_NAME}|g" recipe.yml
     sed -i "s|@@BINARY_NAME@@|${BINARY_NAME}|g" recipe.yml
     sed -i "s|@@ICON@@|${APP_NAME_LC}|g" recipe.yml
   fi

--- a/build/linux/appimage/build.sh
+++ b/build/linux/appimage/build.sh
@@ -35,10 +35,12 @@ if [[ "${VSCODE_ARCH}" == "x64" ]]; then
   if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
     sed -i "s|@@NAME@@|${APP_NAME}-Insiders|g" recipe.yml
     sed -i "s|@@APPNAME@@|${BINARY_NAME}|g" recipe.yml
+    sed -i "s|@@BINARY_NAME@@|${BINARY_NAME}|g" recipe.yml
     sed -i "s|@@ICON@@|${APP_NAME_LC}-insiders|g" recipe.yml
   else
     sed -i "s|@@NAME@@|${APP_NAME}|g" recipe.yml
     sed -i "s|@@APPNAME@@|${BINARY_NAME}|g" recipe.yml
+    sed -i "s|@@BINARY_NAME@@|${BINARY_NAME}|g" recipe.yml
     sed -i "s|@@ICON@@|${APP_NAME_LC}|g" recipe.yml
   fi
 

--- a/build/linux/appimage/recipe.yml
+++ b/build/linux/appimage/recipe.yml
@@ -40,6 +40,11 @@ script:
   - export PERLLIB="${HERE}"/usr/share/perl5/:"${HERE}"/usr/lib/perl5/:"${PERLLIB}"
   - export GSETTINGS_SCHEMA_DIR="${HERE}"/usr/share/glib-2.0/schemas/:"${GSETTINGS_SCHEMA_DIR}"
   - export QT_PLUGIN_PATH="${HERE}"/usr/lib/qt4/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib32/qt4/plugins/:"${HERE}"/usr/lib64/qt4/plugins/:"${HERE}"/usr/lib/qt5/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib32/qt5/plugins/:"${HERE}"/usr/lib64/qt5/plugins/:"${QT_PLUGIN_PATH}"
-  - EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2- | sed -e 's|%.||g')
-  - exec ${EXEC} "$@"
+  - EXEC="${HERE}/usr/share/@@APPNAME@@/@@BINARY_NAME@@"
+  - EXEC_CLI="${HERE}/usr/share/@@APPNAME@@/bin/@@BINARY_NAME@@"
+  - if [ "$1" = "--" ]; then
+  -   shift
+  -   exec "${EXEC_CLI}" "$@"
+  - fi
+  - exec "${EXEC}" "$@"
   - EOF

--- a/build/linux/appimage/recipe.yml
+++ b/build/linux/appimage/recipe.yml
@@ -5,7 +5,7 @@
 # wget -c "https://github.com/AppImage/pkg2appimage/raw/master/pkg2appimage"
 # bash -ex pkg2appimage VSCodium
 
-app: @@NAME@@
+app: @@APP_NAME@@
 
 ingredients:
   packages:
@@ -17,11 +17,11 @@ ingredients:
   script:
     - pwd
     - cp ../../../../vscode/.build/linux/deb/amd64/deb/*.deb .
-    - ls @@APPNAME@@_*.deb | cut -d _ -f 2 > VERSION
+    - ls @@BINARY_NAME@@_*.deb | cut -d _ -f 2 > VERSION
 
 script:
-  - sed -i -e 's|/usr/share/pixmaps/||g' usr/share/applications/@@APPNAME@@.desktop
-  - cp usr/share/applications/@@APPNAME@@.desktop .
+  - sed -i -e 's|/usr/share/pixmaps/||g' usr/share/applications/@@BINARY_NAME@@.desktop
+  - cp usr/share/applications/@@BINARY_NAME@@.desktop .
   - cp usr/share/pixmaps/@@ICON@@.png .
   - /usr/bin/convert @@ICON@@.png -resize 512x512 usr/share/icons/hicolor/512x512/apps/@@ICON@@.png
   - /usr/bin/convert @@ICON@@.png -resize 256x256 usr/share/icons/hicolor/256x256/apps/@@ICON@@.png
@@ -29,7 +29,7 @@ script:
   - /usr/bin/convert @@ICON@@.png -resize 64x64 usr/share/icons/hicolor/64x64/apps/@@ICON@@.png
   - /usr/bin/convert @@ICON@@.png -resize 48x48 usr/share/icons/hicolor/48x48/apps/@@ICON@@.png
   - /usr/bin/convert @@ICON@@.png -resize 32x32 usr/share/icons/hicolor/32x32/apps/@@ICON@@.png
-  - ( cd usr/bin/ ; ln -s ../share/@@APPNAME@@/@@APPNAME@@  . )
+  - ( cd usr/bin/ ; ln -s ../share/@@BINARY_NAME@@/@@BINARY_NAME@@  . )
   - rm -rf usr/lib/x86_64-linux-gnu
   - rm -f lib/x86_64-linux-gnu/libglib*
   - cat > AppRun <<\EOF
@@ -40,8 +40,8 @@ script:
   - export PERLLIB="${HERE}"/usr/share/perl5/:"${HERE}"/usr/lib/perl5/:"${PERLLIB}"
   - export GSETTINGS_SCHEMA_DIR="${HERE}"/usr/share/glib-2.0/schemas/:"${GSETTINGS_SCHEMA_DIR}"
   - export QT_PLUGIN_PATH="${HERE}"/usr/lib/qt4/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt4/plugins/:"${HERE}"/usr/lib32/qt4/plugins/:"${HERE}"/usr/lib64/qt4/plugins/:"${HERE}"/usr/lib/qt5/plugins/:"${HERE}"/usr/lib/i386-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib/x86_64-linux-gnu/qt5/plugins/:"${HERE}"/usr/lib32/qt5/plugins/:"${HERE}"/usr/lib64/qt5/plugins/:"${QT_PLUGIN_PATH}"
-  - EXEC="${HERE}/usr/share/@@APPNAME@@/@@BINARY_NAME@@"
-  - EXEC_CLI="${HERE}/usr/share/@@APPNAME@@/bin/@@BINARY_NAME@@"
+  - EXEC="${HERE}/usr/share/@@BINARY_NAME@@/@@BINARY_NAME@@"
+  - EXEC_CLI="${HERE}/usr/share/@@BINARY_NAME@@/bin/@@BINARY_NAME@@"
   - if [ "$1" = "--" ]; then
   -   shift
   -   exec "${EXEC_CLI}" "$@"


### PR DESCRIPTION


When doing commands such as below, it opens an instance of codium instead of listing active extensions in cli or installing extensions. 
```
vscodium.AppImage --list-extensions

vscodium.AppImage --install-extension

```

This PR fixes that by using a simpler approach rather than adjusting for each possible command. The following syntax will properly work and installing extensions are also properly working even with a custom --extensions-dir
```
vscodium.AppImage -- --list-extensions
vscodium.AppImage -- --install-extension
```

For running the app normally  you can still use the following

```
vscodium.AppImage

vscodium.AppImage --user-data-dir /home/user/mycustomdata  --extensions-dir /home/user/mycustomextension
```
