### PR TITLE
fix: ensure build stops if prepare_vscode fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,10 @@ if [[ "${SHOULD_BUILD}" == "yes" ]]; then
   echo "MS_COMMIT=\"${MS_COMMIT}\""
 
   . prepare_vscode.sh
+  if [ $? -ne 0 ]; then
+    echo "Preparation failed. Build aborted."
+    exit 1
+  fi
 
   cd vscode || { echo "'vscode' dir not found"; exit 1; }
 


### PR DESCRIPTION
Add error handling for preparation step in build script