### PR TITLE
fix(msi): use .msi as extension for updater file

### DIFF
--- a/patches/11-update-use-github-release.patch
+++ b/patches/11-update-use-github-release.patch
@@ -273,7 +273,7 @@ index 2be53f61..53904dab 100644
 +
  				this.setState(State.Idle(UpdateType.Archive, message));
 diff --git a/src/vs/platform/update/electron-main/updateService.win32.ts b/src/vs/platform/update/electron-main/updateService.win32.ts
-index a7851933..b49db325 100644
+index a7851933..c9157f60 100644
 --- a/src/vs/platform/update/electron-main/updateService.win32.ts
 +++ b/src/vs/platform/update/electron-main/updateService.win32.ts
 @@ -14,3 +14,2 @@ import { CancellationToken, CancellationTokenSource } from '../../../base/common
@@ -304,12 +304,20 @@ index a7851933..b49db325 100644
 +			_updateType = UpdateType.Archive;
 +		}
  	}
-@@ -157,3 +160,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -144,5 +147,6 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+ 			try {
++				const updateType = getUpdateType();
+ 				const updatingVersion = (await readFile(updatingVersionPath, 'utf8')).trim();
+ 				this.logService.info(`update#doCheckForUpdates - application was updating to version ${updatingVersion}`);
+-				const updatePackagePath = await this.getUpdatePackagePath(updatingVersion);
++				const updatePackagePath = await this.getUpdatePackagePath(updatingVersion, updateType);
+ 				if (await pfs.Promises.exists(updatePackagePath)) {
+@@ -157,3 +161,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  		} else {
 -			const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
 +			const fastUpdatesEnabled = getUpdateType() === UpdateType.Setup && this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
  			// GC for background updates in system setup happens via inno_setup since it requires
-@@ -215,12 +218,22 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -215,12 +219,22 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
 -	protected buildUpdateFeedUrl(quality: string, commit: string, options?: IUpdateURLOptions): string | undefined {
 -		let platform = `win32-${process.arch}`;
@@ -340,14 +348,14 @@ index a7851933..b49db325 100644
 -		return createUpdateURL(this.productService.updateUrl!, platform, quality, commit, options);
 +		return createUpdateURL(this.productService, quality, process.platform, process.arch, target);
  	}
-@@ -232,6 +245,2 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -232,6 +246,2 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
 -		const internalOrg = this.getInternalOrg();
 -		const background = !explicit && !internalOrg;
 -		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background, internalOrg });
 -
  		// Only set CheckingForUpdates if we're not already in Overwriting state
-@@ -241,9 +250,13 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -241,9 +251,13 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
 -		const headers = getUpdateRequestHeaders(this.productService.version);
 -		this.requestService.request({ url, headers, callSite: 'updateService.win32.checkForUpdates' }, CancellationToken.None)
@@ -366,7 +374,7 @@ index a7851933..b49db325 100644
 -				if (!update || !update.url || !update.version || !update.productVersion) {
 +				if(!result) {
  					// If we were checking for an overwrite update and found nothing newer,
-@@ -259,2 +272,9 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -259,2 +273,9 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
 +				const { lastest, update } = result;
 +
@@ -376,12 +384,17 @@ index a7851933..b49db325 100644
 +				}
 +
  				if (updateType === UpdateType.Archive) {
-@@ -284,3 +304,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -276,3 +297,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+ 				return this.cleanup(update.version).then(() => {
+-					return this.getUpdatePackagePath(update.version).then(updatePackagePath => {
++					return this.getUpdatePackagePath(update.version, updateType).then(updatePackagePath => {
+ 						return pfs.Promises.exists(updatePackagePath).then(exists => {
+@@ -284,3 +305,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  
 -							return this.requestService.request({ url: update.url, callSite: 'updateService.win32.downloadUpdate' }, CancellationToken.None)
 +							return this.requestService.request({ url: update.url, callSite: NO_FETCH_TELEMETRY }, CancellationToken.None)
  								.then(context => {
-@@ -329,8 +349,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -329,8 +350,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  			})
 -			.then(undefined, err => {
 -				this.telemetryService.publicLog2<{ messageHash: string }, UpdateErrorClassification>('update:error', { messageHash: String(hash(String(err))) });
@@ -393,7 +406,22 @@ index a7851933..b49db325 100644
 -				const message: string | undefined = explicit ? (err.message || err) : undefined;
 +				const message: string | undefined = explicit ? (error.message || error) : undefined;
  
-@@ -394,20 +413,31 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+@@ -354,5 +374,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+ 
+-	private async getUpdatePackagePath(version: string): Promise<string> {
++	private async getUpdatePackagePath(version: string, type: UpdateType): Promise<string> {
+ 		const cachePath = await this.cachePath;
+-		return path.join(cachePath, `CodeSetup-${this.productService.quality}-${version}.exe`);
++		const extension = type == UpdateType.WindowsInstaller ? 'msi' : 'exe'
++
++		return path.join(cachePath, `${this.productService.nameShort.replaceAll(/\s/g, '')}-${this.productService.quality}-${version}.${extension}`);
+ 	}
+@@ -360,3 +382,3 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
+ 	private async cleanup(exceptVersion: string | null = null): Promise<void> {
+-		const filter = exceptVersion ? (one: string) => !(new RegExp(`${this.productService.quality}-${exceptVersion}\\.exe$`).test(one)) : () => true;
++		const filter = exceptVersion ? (one: string) => !(new RegExp(`${this.productService.quality}-${exceptVersion}\\.(exe|msi)$`).test(one)) : () => true;
+ 
+@@ -394,20 +416,31 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
  		await pfs.Promises.writeFile(this.availableUpdate.updateFilePath, 'flag');
 -		const child = spawn(this.availableUpdate.packagePath,
 -			[


### PR DESCRIPTION
A temp file had been added (url -> `.tmp` -> `.exe`) (before was url -> file given by url).
This PR fixes the `.tmp` -> `.exe` so that `.msi` is used for MSI updater

Reference:
- #2810
