### PR TITLE
(fix): Don't set VSCODE_SKIP_SETUPENV on ppc64le

### DIFF
--- a/build/linux/package_bin.sh
+++ b/build/linux/package_bin.sh
@@ -32,7 +32,6 @@ elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   export VSCODE_SYSROOT_PREFIX="-glibc-2.28"
   export ELECTRON_SKIP_BINARY_DOWNLOAD=1
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-  export VSCODE_SKIP_SETUPENV=1
   export VSCODE_ELECTRON_REPOSITORY='lex-ibm/electron-ppc64le-build-scripts'
   export IGNORE_ELECTRON_VERSION="yes"
 elif [[ "${VSCODE_ARCH}" == "riscv64" ]]; then


### PR DESCRIPTION
`VSCODE_SKIP_SETUPENV=1` makes it so that the GUI version ships with libraries compiled for Ubuntu Focal which breaks compatibility with GLIBC_2.28