### PR TITLE
fix(riscv64): fix REH builds

### DIFF
--- a/build/linux/package_reh.sh
+++ b/build/linux/package_reh.sh
@@ -39,7 +39,7 @@ elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   export VSCODE_SYSROOT_REPOSITORY='VSCodium/vscode-linux-build-agent'
   export VSCODE_SYSROOT_VERSION='20260706'
 elif [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
-  VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="vscodium/vscodium-linux-build-agent:focal-devtoolset-riscv64"
+  VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="vscodium/vscodium-linux-build-agent:jammy-devtoolset-riscv64"
 
   export VSCODE_SKIP_SETUPENV=1
   export VSCODE_NODEJS_SITE='https://unofficial-builds.nodejs.org'

--- a/build/linux/package_reh.sh
+++ b/build/linux/package_reh.sh
@@ -40,9 +40,14 @@ elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
   export VSCODE_SYSROOT_VERSION='20260706'
 elif [[ "${VSCODE_ARCH}" == "riscv64" ]]; then
   VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="vscodium/vscodium-linux-build-agent:jammy-devtoolset-riscv64"
+  NODE_VERSION="24.18.0"
+  NODEJS_RELEASE_TAG="v${NODE_VERSION}-riscv64.1"
+  NODEJS_ASSET_NAME="node-v${NODE_VERSION}-linux-${VSCODE_ARCH}-local1.tar.gz"
 
   export VSCODE_SKIP_SETUPENV=1
-  export VSCODE_NODEJS_SITE='https://unofficial-builds.nodejs.org'
+  export VSCODE_NODEJS_REPOSITORY='riscv-forks/node-riscv'
+  export VSCODE_NODEJS_TAG="${NODEJS_RELEASE_TAG}"
+  export VSCODE_NODEJS_NAME="${NODEJS_ASSET_NAME}"
 elif [[ "${VSCODE_ARCH}" == "loong64" ]]; then
   VSCODE_REMOTE_DEPENDENCIES_CONTAINER_NAME="vscodium/vscodium-linux-build-agent:beige-devtoolset-loong64"
 

--- a/patches/linux/41-arch-add-support.patch
+++ b/patches/linux/41-arch-add-support.patch
@@ -16,7 +16,7 @@ diff --git a/build/gulpfile.reh.ts b/build/gulpfile.reh.ts
 index 62c30da5..85817274 100644
 --- a/build/gulpfile.reh.ts
 +++ b/build/gulpfile.reh.ts
-@@ -275,9 +275,24 @@ function nodejs(platform: string, arch: string): NodeJS.ReadWriteStream | undefi
+@@ -275,9 +276,34 @@ function nodejs(platform: string, arch: string): NodeJS.ReadWriteStream | undefi
  		case 'linux': {
 -			const downloaded = (product.nodejsRepository !== 'https://nodejs.org' ?
 -				fetchGithub(product.nodejsRepository, { version: `${nodeVersion}-${internalNodeVersion}`, name: expectedName!, checksumSha256 }) :
@@ -26,7 +26,17 @@ index 62c30da5..85817274 100644
 -				.pipe(util.setExecutableBit('**'))
 -				.pipe(rename('node'));
 +			let downloaded: NodeJS.ReadWriteStream;
-+			if (process.env.VSCODE_NODEJS_SITE && process.env.VSCODE_NODEJS_URLROOT) {
++			if (process.env.VSCODE_NODEJS_REPOSITORY) {
++				const nodejsVersion = (process.env.VSCODE_NODEJS_TAG ?? `${nodeVersion}-${internalNodeVersion}`).replace(/^v/, '');
++				const nodejsName = process.env.VSCODE_NODEJS_NAME ?? expectedName!;
++				const nodejsChecksumSha256 = getNodeChecksum(nodejsName) ?? checksumSha256;
++				downloaded = fetchGithub(process.env.VSCODE_NODEJS_REPOSITORY, { version: nodejsVersion, name: nodejsName, checksumSha256: nodejsChecksumSha256 })
++					.pipe(flatmap(stream => stream.pipe(gunzip()).pipe(untar())))
++					.pipe(filter('**/node'))
++					.pipe(util.setExecutableBit('**'))
++					.pipe(rename('node'));
++			}
++			else if (process.env.VSCODE_NODEJS_SITE && process.env.VSCODE_NODEJS_URLROOT) {
 +				downloaded = fetchUrls(`${process.env.VSCODE_NODEJS_URLROOT}/v${nodeVersion}/node-v${nodeVersion}-${platform}-${arch}${process.env.VSCODE_NODEJS_URLSUFFIX}.tar.gz`, { base: process.env.VSCODE_NODEJS_SITE, checksumSha256 })
 +					.pipe(flatmap(stream => stream.pipe(gunzip()).pipe(untar())))
 +					.pipe(filter('**/node'))

--- a/patches/linux/43-arch-add-riscv64.patch
+++ b/patches/linux/43-arch-add-riscv64.patch
@@ -6,6 +6,16 @@ index f986b4e..557990e 100644
  	{ platform: 'linux', arch: 'ppc64le' },
 +	{ platform: 'linux', arch: 'riscv64' },
  	{ platform: 'alpine', arch: 'arm64' },
+diff --git a/build/checksums/nodejs.txt b/build/checksums/nodejs.txt
+index 12a2a80d..8d429dc4 100644
+--- a/build/checksums/nodejs.txt
++++ b/build/checksums/nodejs.txt
+@@ -2,4 +2,5 @@
+ ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b  node-v24.15.0-darwin-x64.tar.gz
+ 73afc234d558c24919875f51c2d1ea002a2ada4ea6f83601a383869fefa64eed  node-v24.15.0-linux-arm64.tar.gz
+ 44836872d9aec49f1e6b52a9a922872db9a2b02d235a616a5681b6a85fec8d89  node-v24.15.0-linux-x64.tar.gz
++65109e57e34279184efcca5888bc156cff3d24bf8eead73de16a28a313c18884  node-v24.18.0-linux-riscv64-local1.tar.gz
+ 49a54c103f4919ce64199a043ef5cd309507de491d718085edee089cd8e87543  win-arm64/node.exe
 diff --git a/build/gulpfile.scan.ts b/build/gulpfile.scan.ts
 index 47b25cf..dd5bb56 100644
 --- a/build/gulpfile.scan.ts


### PR DESCRIPTION
This PR fixes the REH build failures that first occurred in https://github.com/VSCodium/vscodium/pull/2903.

It increases the glibc version requirement for riscv64 REH builds to 2.35, because ubuntu jammy's cross toolchain uses glibc 2.35 (while the new node.js binary used in this PR supports 2.33).

However, the desktop application builds should still support glibc 2.33, because it is still using `focal-riscv64` whose  cross toolchain uses glibc 2.31 (while the electron riscv64 binary supports 2.33)

The first commit switches to the jammy image. The second one replaces the node.js binary from unofficial-builds with my cross-compiled binary.