### PR TITLE
fix(deb): support libasound2t64

### DIFF
--- a/patches/linux/46-deb-use-libasound2t64-compat.patch
+++ b/patches/linux/46-deb-use-libasound2t64-compat.patch
@@ -2,52 +2,65 @@ diff --git a/build/linux/debian/calculate-deps.ts b/build/linux/debian/calculate
 index 2523941a..8d521dd6 100644
 --- a/build/linux/debian/calculate-deps.ts
 +++ b/build/linux/debian/calculate-deps.ts
-@@ -81,3 +81,7 @@ function calculatePackageDeps(binaryPath: string, arch: DebianArchString, chromi
-	// TODO(deepak1556): remove this workaround in favor of computing the
-	// versions from build container for native modules.
-	const filteredDeps = depsStr.split(', ').filter(dependency => {
-		return !dependency.startsWith('libgcc-s1');
-	}).map(dependency => {
-		return dependency.startsWith('libasound2 (>= 1.0.17)') ? 'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2' : dependency;
-	}).sort();
-	const requires = new Set(filteredDeps);
+@@ -88,6 +88,8 @@ function calculatePackageDeps(binaryPath: string, arch: DebianArchString, chromi
+ 	// TODO(deepak1556): remove this workaround in favor of computing the
+ 	// versions from build container for native modules.
+ 	const filteredDeps = depsStr.split(', ').filter(dependency => {
+ 		return !dependency.startsWith('libgcc-s1');
++	}).map(dependency => {
++		return dependency.startsWith('libasound2 (>= 1.0.17)') ? 'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2' : dependency;
+ 	}).sort();
+ 	const requires = new Set(filteredDeps);
+ 	return requires;
 diff --git a/build/linux/debian/dep-lists.ts b/build/linux/debian/dep-lists.ts
 index 6e81b12..f233d6f 100644
 --- a/build/linux/debian/dep-lists.ts
 +++ b/build/linux/debian/dep-lists.ts
-@@ -21,3 +21,3 @@ export const referenceGeneratedDepsByArch = {
-	'amd64': [
-		'ca-certificates',
+@@ -22,6 +22,6 @@ export const referenceGeneratedDepsByArch = {
+ 	'amd64': [
+ 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
 +		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
-		'libatk-bridge2.0-0 (>= 2.5.3)',
-@@ -58,3 +58,3 @@ export const referenceGeneratedDepsByArch = {
-	'armhf': [
-		'ca-certificates',
+ 		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk1.0-0 (>= 2.11.90)',
+ 		'libatspi2.0-0 (>= 2.9.90)',
+@@ -59,6 +59,6 @@ export const referenceGeneratedDepsByArch = {
+ 	'armhf': [
+ 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
 +		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
-		'libatk-bridge2.0-0 (>= 2.5.3)',
-@@ -100,3 +100,3 @@ export const referenceGeneratedDepsByArch = {
-	'arm64': [
-		'ca-certificates',
+ 		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk1.0-0 (>= 2.11.90)',
+ 		'libatspi2.0-0 (>= 2.9.90)',
+@@ -101,6 +101,6 @@ export const referenceGeneratedDepsByArch = {
+ 	'arm64': [
+ 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
 +		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
-		'libatk-bridge2.0-0 (>= 2.5.3)',
-@@ -145,3 +145,3 @@ export const referenceGeneratedDepsByArch = {
-	'ppc64el': [
-		'ca-certificates',
+ 		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk1.0-0 (>= 2.11.90)',
+ 		'libatspi2.0-0 (>= 2.9.90)',
+@@ -146,6 +146,6 @@ export const referenceGeneratedDepsByArch = {
+ 	'ppc64el': [
+ 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
 +		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
-		'libatk-bridge2.0-0 (>= 2.5.3)',
-@@ -186,3 +186,3 @@ export const referenceGeneratedDepsByArch = {
-	'riscv64': [
-		'ca-certificates',
+ 		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk1.0-0 (>= 2.2.0)',
+ 		'libatspi2.0-0 (>= 2.9.90)',
+@@ -187,6 +187,6 @@ export const referenceGeneratedDepsByArch = {
+ 	'riscv64': [
+ 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
 +		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
-		'libatk-bridge2.0-0 (>= 2.5.3)',
-@@ -227,3 +227,3 @@ export const referenceGeneratedDepsByArch = {
-	's390x': [
-		'ca-certificates',
+ 		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk1.0-0 (>= 2.2.0)',
+ 		'libatspi2.0-0 (>= 2.9.90)',
+@@ -228,6 +228,6 @@ export const referenceGeneratedDepsByArch = {
+ 	's390x': [
+ 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
 +		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
-		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk-bridge2.0-0 (>= 2.5.3)',
+ 		'libatk1.0-0 (>= 2.2.0)',
+ 		'libatspi2.0-0 (>= 2.9.90)',

--- a/patches/linux/46-deb-use-libasound2t64-compat.patch
+++ b/patches/linux/46-deb-use-libasound2t64-compat.patch
@@ -8,7 +8,7 @@ index 2523941a..8d521dd6 100644
 	const filteredDeps = depsStr.split(', ').filter(dependency => {
 		return !dependency.startsWith('libgcc-s1');
 	}).map(dependency => {
-		return dependency.startsWith('libasound2 (>= 1.0.17)') ? 'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)' : dependency;
+		return dependency.startsWith('libasound2 (>= 1.0.17)') ? 'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2' : dependency;
 	}).sort();
 	const requires = new Set(filteredDeps);
 diff --git a/build/linux/debian/dep-lists.ts b/build/linux/debian/dep-lists.ts
@@ -19,35 +19,35 @@ index 6e81b12..f233d6f 100644
 	'amd64': [
 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
-+		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
 		'libatk-bridge2.0-0 (>= 2.5.3)',
 @@ -58,3 +58,3 @@ export const referenceGeneratedDepsByArch = {
 	'armhf': [
 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
-+		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
 		'libatk-bridge2.0-0 (>= 2.5.3)',
 @@ -100,3 +100,3 @@ export const referenceGeneratedDepsByArch = {
 	'arm64': [
 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
-+		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
 		'libatk-bridge2.0-0 (>= 2.5.3)',
 @@ -145,3 +145,3 @@ export const referenceGeneratedDepsByArch = {
 	'ppc64el': [
 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
-+		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
 		'libatk-bridge2.0-0 (>= 2.5.3)',
 @@ -186,3 +186,3 @@ export const referenceGeneratedDepsByArch = {
 	'riscv64': [
 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
-+		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
 		'libatk-bridge2.0-0 (>= 2.5.3)',
 @@ -227,3 +227,3 @@ export const referenceGeneratedDepsByArch = {
 	's390x': [
 		'ca-certificates',
 -		'libasound2 (>= 1.0.17)',
-+		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2',
 		'libatk-bridge2.0-0 (>= 2.5.3)',

--- a/patches/linux/46-deb-use-libasound2t64-compat.patch
+++ b/patches/linux/46-deb-use-libasound2t64-compat.patch
@@ -1,0 +1,53 @@
+diff --git a/build/linux/debian/calculate-deps.ts b/build/linux/debian/calculate-deps.ts
+index 2523941a..8d521dd6 100644
+--- a/build/linux/debian/calculate-deps.ts
++++ b/build/linux/debian/calculate-deps.ts
+@@ -81,3 +81,7 @@ function calculatePackageDeps(binaryPath: string, arch: DebianArchString, chromi
+	// TODO(deepak1556): remove this workaround in favor of computing the
+	// versions from build container for native modules.
+	const filteredDeps = depsStr.split(', ').filter(dependency => {
+		return !dependency.startsWith('libgcc-s1');
+	}).map(dependency => {
+		return dependency.startsWith('libasound2 (>= 1.0.17)') ? 'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)' : dependency;
+	}).sort();
+	const requires = new Set(filteredDeps);
+diff --git a/build/linux/debian/dep-lists.ts b/build/linux/debian/dep-lists.ts
+index 6e81b12..f233d6f 100644
+--- a/build/linux/debian/dep-lists.ts
++++ b/build/linux/debian/dep-lists.ts
+@@ -21,3 +21,3 @@ export const referenceGeneratedDepsByArch = {
+	'amd64': [
+		'ca-certificates',
+-		'libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
+		'libatk-bridge2.0-0 (>= 2.5.3)',
+@@ -58,3 +58,3 @@ export const referenceGeneratedDepsByArch = {
+	'armhf': [
+		'ca-certificates',
+-		'libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
+		'libatk-bridge2.0-0 (>= 2.5.3)',
+@@ -100,3 +100,3 @@ export const referenceGeneratedDepsByArch = {
+	'arm64': [
+		'ca-certificates',
+-		'libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
+		'libatk-bridge2.0-0 (>= 2.5.3)',
+@@ -145,3 +145,3 @@ export const referenceGeneratedDepsByArch = {
+	'ppc64el': [
+		'ca-certificates',
+-		'libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
+		'libatk-bridge2.0-0 (>= 2.5.3)',
+@@ -186,3 +186,3 @@ export const referenceGeneratedDepsByArch = {
+	'riscv64': [
+		'ca-certificates',
+-		'libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
+		'libatk-bridge2.0-0 (>= 2.5.3)',
+@@ -227,3 +227,3 @@ export const referenceGeneratedDepsByArch = {
+	's390x': [
+		'ca-certificates',
+-		'libasound2 (>= 1.0.17)',
++		'libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17)',
+		'libatk-bridge2.0-0 (>= 2.5.3)',


### PR DESCRIPTION
## Summary

- add a Debian packaging patch that rewrites the generated ALSA dependency to libasound2t64 (>= 1.2.12) | libasound2 (>= 1.0.17) | liboss4-salsa-asound2
- update the Debian reference dependency lists for all shipped deb arches to match the generated package metadata
- keep compatibility with Debian 13 while preserving fallback options for older Debian and Ubuntu systems

## Changes

### Debian ALSA dependency

- patches/linux/46-deb-use-libasound2t64-compat.patch: rewrite libasound2 dep to libasound2t64 | libasound2 | liboss4-salsa-asound2 in both calculate-deps.ts and dep-lists.ts

## Testing

- inspected the Linux release packaging flow and Debian dependency generation path
- validated the packaging patch against the current upstream vscode Debian packaging files and VSCodium Linux patch sequence