### PR TITLE
Honor custom product branding

### DIFF
--- a/patches/00-brand-remove-branding.patch
+++ b/patches/00-brand-remove-branding.patch
@@ -888,8 +888,8 @@ index 0c0965d3..9b9876ee 100644
  						Severity.Info,
 -						vsixs.length > 1 ? localize('InstallVSIXs.successReload', "Completed installing extensions. Please reload Visual Studio Code to enable them.")
 -							: localize('InstallVSIXAction.successReload', "Completed installing extension. Please reload Visual Studio Code to enable it."),
-+						vsixs.length > 1 ? localize('InstallVSIXs.successReload', "Completed installing extensions. Please reload VSCodium to enable them.")
-+							: localize('InstallVSIXAction.successReload', "Completed installing extension. Please reload VSCodium to enable it."),
++						vsixs.length > 1 ? localize('InstallVSIXs.successReload', "Completed installing extensions. Please reload !!APP_NAME!! to enable them.")
++							: localize('InstallVSIXAction.successReload', "Completed installing extension. Please reload !!APP_NAME!! to enable it."),
  						[{
 diff --git a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
 index 452db88d..cd67d238 100644

--- a/patches/21-policy-use-custom-lib.patch
+++ b/patches/21-policy-use-custom-lib.patch
@@ -47,17 +47,17 @@ index bd5958cb..3f62d83f 100644
 @@ -192,3 +192,3 @@ export function renderProfileManifest(appName: string, bundleIdentifier: string,
      <key>pfm_app_url</key>
 -    <string>https://code.visualstudio.com/</string>
-+    <string>https://github.com/VSCodium/vscodium</string>
++    <string>https://github.com/!!GH_REPO_PATH!!</string>
      <key>pfm_description</key>
 @@ -196,3 +196,3 @@ export function renderProfileManifest(appName: string, bundleIdentifier: string,
      <key>pfm_documentation_url</key>
 -    <string>https://code.visualstudio.com/docs/setup/enterprise</string>
-+    <string>https://github.com/VSCodium/vscodium</string>
++    <string>https://github.com/!!GH_REPO_PATH!!</string>
      <key>pfm_domain</key>
 @@ -262,3 +262,3 @@ ${policyEntries}
  		<key>PayloadDescription</key>
 -		<string>This profile manages ${appName}. For more information see https://code.visualstudio.com/docs/setup/enterprise</string>
-+		<string>This profile manages ${appName}. For more information see https://github.com/VSCodium/vscodium</string>
++		<string>This profile manages ${appName}. For more information see https://github.com/!!GH_REPO_PATH!!</string>
  		<key>PayloadDisplayName</key>
 @@ -268,3 +268,3 @@ ${policyEntries}
  		<key>PayloadOrganization</key>


### PR DESCRIPTION
We're working on a fork of vscodium rebranded for our use. While going through this, we've noticed a few things that were hardcoded that could easily be fixed to not be hardcoded.

For this change, it uses the existing APP_NAME and GH_REPO_PATH placeholders in extension reload prompts and macOS policy metadata. These variables were already used in a few places in these patches, just not everywhere.

This PR was helped to be created with Codex, but was fully validated and tested by me.