### PR TITLE
Honor disabled CLI builds

### DIFF
--- a/build_cli.sh
+++ b/build_cli.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ "${SHOULD_BUILD_CLI}" == "no" ]]; then
+  echo "Skipping CLI build"
+  return 0
+fi
+
 set -ex
 
 cd cli


### PR DESCRIPTION
Return before installing Rust targets and OpenSSL artifacts when SHOULD_BUILD_CLI is set to no. Platform packaging scripts already source this helper and propagate the option.

There was AI assistance in this PR for the larger patch set, however has been fully reviewed by me and is a minor change.