### PR TITLE
Preserve the update-disable patch

### DIFF
--- a/prepare_vscode.sh
+++ b/prepare_vscode.sh
@@ -144,7 +144,7 @@ echo "ORG_NAME=\"${ORG_NAME}\""
 echo "TUNNEL_APP_NAME=\"${TUNNEL_APP_NAME}\""
 
 if [[ "${DISABLE_UPDATE}" == "yes" ]]; then
-  mv ../patches/00-update-disable.patch.yet ../patches/00-update-disable.patch
+  apply_patch ../patches/00-update-disable.patch.yet
 fi
 
 for file in ../patches/*.json; do


### PR DESCRIPTION
Apply 00-update-disable.patch.yet directly instead of renaming it into the regular patch set. This keeps the checkout unchanged and allows repeated preparation runs to find the source patch.

There was AI assistance in this PR for the larger patch set, however has been fully reviewed by me and is a minor change.