### PR TITLE
feat(ci): add non-interactive patch validation to all workflows

### DIFF
--- a/.github/workflows/ci-build-linux.yml
+++ b/.github/workflows/ci-build-linux.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Clone VSCode repo
         run: ./get_repo.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+
       - name: Build
         env:
           SHOULD_BUILD: yes
@@ -91,6 +94,14 @@ jobs:
           echo "vscode/.build/extensions/node_modules" >> vscode.txt
           echo "vscode/.git" >> vscode.txt
           tar -czf vscode.tar.gz -T vscode.txt
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-compile-linux
+          path: ./.patch-check/
+          retention-days: 3
+        if: always()
 
       - name: Upload vscode artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -171,6 +182,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes'
 
+      - name: Validate package patches
+        run: bash ./dev/check_patches.sh linux-client
+        if: env.DISABLED != 'yes'
+
       - name: Build
         id: build
         env:
@@ -199,6 +214,14 @@ jobs:
           VSCODE_SYSROOT_PREFIX: ${{ steps.build.outputs.VSCODE_SYSROOT_PREFIX }}
         run: ./prepare_assets.sh
         if: env.DISABLED != 'yes' && github.event.inputs.generate_assets == 'true'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-linux-bin-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'
 
       - name: Upload assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -335,6 +358,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no' || github.event.inputs.generate_assets == 'true')
 
+      - name: Validate REH patches
+        run: bash ./dev/check_patches.sh linux-reh
+        if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no' || github.event.inputs.generate_assets == 'true')
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -349,6 +376,14 @@ jobs:
           path: assets/
           retention-days: 3
         if: env.DISABLED != 'yes' && github.event.inputs.generate_assets == 'true'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-linux-reh-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'
 
   reh_alpine:
     needs:
@@ -407,6 +442,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no' || github.event.inputs.generate_assets == 'true')
 
+      - name: Validate Alpine REH patches
+        run: bash ./dev/check_patches.sh alpine-reh
+        if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no' || github.event.inputs.generate_assets == 'true')
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -421,3 +460,11 @@ jobs:
           path: assets/
           retention-days: 3
         if: env.DISABLED != 'yes' && github.event.inputs.generate_assets == 'true'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-alpine-reh-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'

--- a/.github/workflows/ci-build-macos.yml
+++ b/.github/workflows/ci-build-macos.yml
@@ -72,11 +72,22 @@ jobs:
       - name: Clone VSCode repo
         run: . get_repo.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+
       - name: Build
         env:
           SHOULD_BUILD: yes
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build.sh
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-macos-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always()
 
       - name: Prepare assets
         run: ./prepare_assets.sh

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Clone VSCode repo
         run: ./get_repo.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+
       - name: Build
         env:
           SHOULD_BUILD: yes
@@ -83,6 +86,14 @@ jobs:
           echo "vscode/.build/extensions/node_modules" >> vscode.txt
           echo "vscode/.git" >> vscode.txt
           tar -czf vscode.tar.gz -T vscode.txt
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-compile-windows
+          path: ./.patch-check/
+          retention-days: 3
+        if: always()
 
       - name: Upload vscode artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/publish-insider-linux.yml
+++ b/.github/workflows/publish-insider-linux.yml
@@ -92,6 +92,10 @@ jobs:
         run: ./get_repo.sh
         if: env.SHOULD_BUILD == 'yes'
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+        if: env.SHOULD_BUILD == 'yes'
+
       - name: Build
         env:
           SHOULD_BUILD_REH: no
@@ -114,6 +118,14 @@ jobs:
           path: ./vscode.tar.gz
           retention-days: 30
         if: env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-compile-linux-insider
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.SHOULD_BUILD == 'yes'
 
   build:
     needs:
@@ -195,6 +207,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
 
+      - name: Validate package patches
+        run: bash ./dev/check_patches.sh linux-client
+        if: env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
+
       - name: Build
         id: build
         env:
@@ -237,6 +253,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./update_version.sh
         if: env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-linux-bin-insider-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
 
   anylinux-appimage:
     needs:
@@ -383,6 +407,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
 
+      - name: Validate REH patches
+        run: bash ./dev/check_patches.sh linux-reh
+        if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -396,6 +424,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./release.sh
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-linux-reh-insider-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'
 
   reh_alpine:
     needs:
@@ -462,6 +498,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
 
+      - name: Validate Alpine REH patches
+        run: bash ./dev/check_patches.sh alpine-reh
+        if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -475,6 +515,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./release.sh
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-alpine-reh-insider-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'
 
   aur:
     needs:

--- a/.github/workflows/publish-insider-macos.yml
+++ b/.github/workflows/publish-insider-macos.yml
@@ -60,6 +60,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: . check_tags.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+        if: env.SHOULD_BUILD == 'yes'
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,6 +93,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./update_version.sh
         if: env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-publish-macos-insider-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.SHOULD_BUILD == 'yes'
 
       - name: Clean up keychain
         if: always()

--- a/.github/workflows/publish-insider-spearhead.yml
+++ b/.github/workflows/publish-insider-spearhead.yml
@@ -81,10 +81,21 @@ jobs:
       - name: Clone VSCode repo
         run: . get_repo.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build.sh
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-spearhead-insider
+          path: ./.patch-check/
+          retention-days: 3
+        if: always()
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0

--- a/.github/workflows/publish-insider-windows.yml
+++ b/.github/workflows/publish-insider-windows.yml
@@ -82,6 +82,10 @@ jobs:
         run: ./get_repo.sh
         if: env.SHOULD_BUILD == 'yes'
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+        if: env.SHOULD_BUILD == 'yes'
+
       - name: Build
         env:
           SHOULD_BUILD_REH: no
@@ -104,6 +108,14 @@ jobs:
           path: ./vscode.tar.gz
           retention-days: 30
         if: env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-compile-windows-insider
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.SHOULD_BUILD == 'yes'
 
   build:
     needs:

--- a/.github/workflows/publish-stable-linux.yml
+++ b/.github/workflows/publish-stable-linux.yml
@@ -93,6 +93,10 @@ jobs:
         run: ./get_repo.sh
         if: env.SHOULD_BUILD == 'yes'
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+        if: env.SHOULD_BUILD == 'yes'
+
       - name: Build
         env:
           SHOULD_BUILD_REH: no
@@ -115,6 +119,14 @@ jobs:
           path: ./vscode.tar.gz
           retention-days: 30
         if: env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-compile-linux-stable
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.SHOULD_BUILD == 'yes'
 
   build:
     needs:
@@ -196,6 +208,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
 
+      - name: Validate package patches
+        run: bash ./dev/check_patches.sh linux-client
+        if: env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
+
       - name: Build
         id: build
         env:
@@ -238,6 +254,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./update_version.sh
         if: env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-linux-bin-stable-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes' && env.SHOULD_BUILD == 'yes'
 
   anylinux-appimage:
     needs:
@@ -384,6 +408,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
 
+      - name: Validate REH patches
+        run: bash ./dev/check_patches.sh linux-reh
+        if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -397,6 +425,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./release.sh
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-linux-reh-stable-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'
 
   reh_alpine:
     needs:
@@ -463,6 +499,10 @@ jobs:
           name: vscode
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
 
+      - name: Validate Alpine REH patches
+        run: bash ./dev/check_patches.sh alpine-reh
+        if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -476,6 +516,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./release.sh
         if: env.DISABLED != 'yes' && (env.SHOULD_BUILD_REH != 'no' || env.SHOULD_BUILD_REH_WEB != 'no')
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-alpine-reh-stable-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.DISABLED != 'yes'
 
   aur:
     needs:

--- a/.github/workflows/publish-stable-macos.yml
+++ b/.github/workflows/publish-stable-macos.yml
@@ -60,6 +60,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: . check_tags.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+        if: env.SHOULD_BUILD == 'yes'
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -88,6 +92,14 @@ jobs:
           GITHUB_USERNAME: ${{ github.repository_owner }}
         run: ./update_version.sh
         if: env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-publish-macos-stable-${{ matrix.vscode_arch }}
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.SHOULD_BUILD == 'yes'
 
       - name: Clean up keychain
         if: always()

--- a/.github/workflows/publish-stable-spearhead.yml
+++ b/.github/workflows/publish-stable-spearhead.yml
@@ -81,10 +81,21 @@ jobs:
       - name: Clone VSCode repo
         run: . get_repo.sh
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build.sh
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-spearhead-stable
+          path: ./.patch-check/
+          retention-days: 3
+        if: always()
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0

--- a/.github/workflows/publish-stable-windows.yml
+++ b/.github/workflows/publish-stable-windows.yml
@@ -82,6 +82,10 @@ jobs:
         run: ./get_repo.sh
         if: env.SHOULD_BUILD == 'yes'
 
+      - name: Validate compile-time patches
+        run: bash ./dev/check_patches.sh compile
+        if: env.SHOULD_BUILD == 'yes'
+
       - name: Build
         env:
           SHOULD_BUILD_REH: no
@@ -104,6 +108,14 @@ jobs:
           path: ./vscode.tar.gz
           retention-days: 30
         if: env.SHOULD_BUILD == 'yes'
+
+      - name: Upload patch validation logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: patch-check-compile-windows-stable
+          path: ./.patch-check/
+          retention-days: 3
+        if: always() && env.SHOULD_BUILD == 'yes'
 
   build:
     needs:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Please note that some Visual Studio Code extensions have licenses that restrict 
 
 If you would like to see the commands we run to build `vscode` into VSCodium binaries, have a look at the workflow files in `.github/workflows` for Windows, GNU/Linux and macOS. These build files call all the other scripts in the repo. If you find something that doesn't make sense, feel free to ask about it [on Gitter](https://gitter.im/VSCodium/Lobby).
 
+Patch applicability is also validated in GitHub Actions before the main build and packaging phases, using `bash ./dev/check_patches.sh` and uploading `.patch-check/` logs as workflow artifacts.
+
 The builds are run every day, but exit early if there isn't a new release from Microsoft.
 
 ## <a id="supported-platforms"></a>Supported Platforms

--- a/dev/check_patches.sh
+++ b/dev/check_patches.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( dirname -- "${SCRIPT_DIR}" )"
+OUTPUT_DIR="${PATCH_CHECK_DIR:-${REPO_ROOT}/.patch-check}"
+SCOPE="${1:-compile}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+LOG_FILE="${OUTPUT_DIR}/${SCOPE}.log"
+exec > >(tee "${LOG_FILE}") 2>&1
+
+if [[ -z "${RELEASE_VERSION:-}" ]]; then
+  export RELEASE_VERSION='0.0.0'
+fi
+
+shopt -s nullglob
+
+TMP_DIR="$( mktemp -d "${TMPDIR:-/tmp}/vscodium-patch-check.XXXXXX" )"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+# include common functions
+. "${REPO_ROOT}/utils.sh"
+
+apply_patch_group() {
+  local file
+
+  for file in "$@"; do
+    if [[ -f "${file}" ]]; then
+      apply_patch "${file}"
+    fi
+  done
+}
+
+prepare_compile_tree() {
+  local source_dir="${REPO_ROOT}/vscode"
+  local quality_dir="${REPO_ROOT}/src/${VSCODE_QUALITY}"
+
+  if [[ ! -d "${source_dir}" ]]; then
+    echo "${source_dir} not found"
+    exit 1
+  fi
+
+  git clone --quiet --shared "${source_dir}" "${TMP_DIR}/vscode"
+
+  if [[ -d "${quality_dir}" ]]; then
+    cp -rp "${quality_dir}"/* "${TMP_DIR}/vscode/"
+  fi
+
+  cp -f "${REPO_ROOT}/LICENSE" "${TMP_DIR}/vscode/LICENSE.txt"
+}
+
+prepare_archive_tree() {
+  local archive_path="${REPO_ROOT}/vscode.tar.gz"
+
+  if [[ ! -f "${archive_path}" ]]; then
+    echo "${archive_path} not found"
+    exit 1
+  fi
+
+  tar -xzf "${archive_path}" -C "${TMP_DIR}"
+}
+
+apply_compile_patches() {
+  local file
+
+  cd "${TMP_DIR}/vscode" || exit 1
+
+  if [[ "${DISABLE_UPDATE:-}" == "yes" ]] && [[ -f "${REPO_ROOT}/patches/00-update-disable.patch.yet" ]]; then
+    apply_patch "${REPO_ROOT}/patches/00-update-disable.patch.yet"
+  fi
+
+  for file in "${REPO_ROOT}/patches/"*.json; do
+    if [[ -f "${file}" ]]; then
+      apply_actions "${file}"
+    fi
+  done
+
+  apply_patch_group "${REPO_ROOT}/patches/"*.patch
+
+  if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
+    apply_patch_group "${REPO_ROOT}/patches/insider/"*.patch
+  fi
+
+  apply_patch_group "${REPO_ROOT}/patches/${OS_NAME}/"*.patch
+  apply_patch_group "${REPO_ROOT}/patches/user/"*.patch
+}
+
+apply_linux_client_patches() {
+  cd "${TMP_DIR}/vscode" || exit 1
+  apply_patch_group "${REPO_ROOT}/patches/linux/client/"*.patch
+}
+
+apply_linux_reh_patches() {
+  cd "${TMP_DIR}/vscode" || exit 1
+  apply_patch_group "${REPO_ROOT}/patches/linux/reh/"*.patch
+  apply_patch_group "${REPO_ROOT}/patches/linux/reh/${VSCODE_ARCH:-}/"*.patch
+}
+
+apply_alpine_reh_patches() {
+  cd "${TMP_DIR}/vscode" || exit 1
+  apply_patch_group "${REPO_ROOT}/patches/alpine/reh/"*.patch
+}
+
+case "${SCOPE}" in
+  compile)
+    if [[ -z "${OS_NAME:-}" ]]; then
+      echo "OS_NAME is required for compile"
+      exit 1
+    fi
+
+    if [[ -z "${VSCODE_QUALITY:-}" ]]; then
+      echo "VSCODE_QUALITY is required for compile"
+      exit 1
+    fi
+
+    prepare_compile_tree
+    apply_compile_patches
+    ;;
+  linux-client)
+    export OS_NAME="${OS_NAME:-linux}"
+    prepare_archive_tree
+    apply_linux_client_patches
+    ;;
+  linux-reh)
+    export OS_NAME="${OS_NAME:-linux}"
+    prepare_archive_tree
+    apply_linux_reh_patches
+    ;;
+  alpine-reh)
+    export OS_NAME="${OS_NAME:-alpine}"
+    prepare_archive_tree
+    apply_alpine_reh_patches
+    ;;
+  *)
+    echo "Unknown scope: ${SCOPE}"
+    exit 1
+    ;;
+esac
+
+echo "Patch validation succeeded for scope: ${SCOPE}"

--- a/docs/howto-build.md
+++ b/docs/howto-build.md
@@ -190,6 +190,7 @@ review-tools.snap-review --allow-classic codium*.snap
 
 - run `./dev/build.sh`, if a patch is failing then,
 - run `./dev/update_patches.sh`
+- GitHub Actions now runs `bash ./dev/check_patches.sh <scope>` before build/package steps to catch malformed or stale patches automatically
 - when the script pauses at `Press any key when the conflict have been resolved...`, open `vscode` directory in **VSCodium**
 - fix all the `*.rej` files
 - run `npm run watch`
@@ -200,11 +201,22 @@ review-tools.snap-review --allow-classic codium*.snap
 
 - run `./dev/build.sh`, if a patch is failing then,
 - run `./dev/patch.sh <name>.patch` where `<name>.patch` is the failed patch
+- use this local script when CI patch validation reports a malformed patch or an apply failure that needs manual regeneration
 - open `vscode` directory in a new **VSCodium**'s window
 - fix all the `*.rej` files
 - run `npm run watch`
 - run `./script/code.sh` until everything is ok
 - go back to the command line running `./dev/patch.sh`, press `enter` to validate the changes and it will update the patch
+
+### Automated patch validation in GitHub Actions
+
+- `OS_NAME` and `VSCODE_QUALITY` are required for `compile`; package scopes infer `OS_NAME` automatically
+- `bash ./dev/check_patches.sh compile` validates compile-time patches against a fresh `vscode` checkout
+- `bash ./dev/check_patches.sh linux-client` validates Linux client packaging patches against `vscode.tar.gz`
+- `bash ./dev/check_patches.sh linux-reh` validates Linux REH packaging patches against `vscode.tar.gz`
+- `bash ./dev/check_patches.sh alpine-reh` validates Alpine REH packaging patches against `vscode.tar.gz`
+- example: `export OS_NAME=linux VSCODE_QUALITY=stable && bash ./dev/check_patches.sh compile`
+- workflows upload `.patch-check/` logs as artifacts so maintainers can inspect failures without reproducing them locally first
 
 ### <a id="icons"></a>icons/build_icons.sh
 

--- a/docs/patches.md
+++ b/docs/patches.md
@@ -2,6 +2,14 @@
 
 Documentation for VSCodium patches applied on top of VS Code.
 
+## Validation and maintenance
+
+- GitHub Actions validates patch applicability before the main build and packaging steps.
+- The non-interactive validator is `bash ./dev/check_patches.sh <scope>`.
+- `compile` expects `OS_NAME`, `VSCODE_QUALITY`, and a prepared `vscode/` checkout; package scopes expect `vscode.tar.gz`.
+- Logs are written to `.patch-check/` and uploaded as workflow artifacts.
+- Local regeneration is still done with `./dev/patch.sh <name>.patch` or `./dev/update_patches.sh` when a patch needs human conflict resolution.
+
 ---
 
 ## fix-policies


### PR DESCRIPTION
## Summary

- add non-interactive patch validation (dev/check_patches.sh) to all CI and publish workflows across Linux, macOS, and Windows
- upload .patch-check/ logs as workflow artifacts on every run for easy failure triage
- update docs/howto-build.md, docs/patches.md, and README.md with CI patch validation instructions

## Changes

### Patch validation automation

- dev/check_patches.sh: non-interactive script with scopes compile, linux-client, linux-reh, alpine-reh
- .github/workflows/ci-build-linux.yml: validate compile, linux-client, linux-reh, alpine-reh patches
- .github/workflows/ci-build-macos.yml: validate compile patches
- .github/workflows/ci-build-windows.yml: validate compile patches
- .github/workflows/publish-stable-linux.yml: validate compile, linux-client, linux-reh, alpine-reh patches
- .github/workflows/publish-insider-linux.yml: validate compile, linux-client, linux-reh, alpine-reh patches
- .github/workflows/publish-stable-macos.yml: validate compile patches
- .github/workflows/publish-insider-macos.yml: validate compile patches
- .github/workflows/publish-stable-windows.yml: validate compile patches
- .github/workflows/publish-insider-windows.yml: validate compile patches
- .github/workflows/publish-stable-spearhead.yml: validate compile patches
- .github/workflows/publish-insider-spearhead.yml: validate compile patches

### Documentation

- docs/howto-build.md: document CI patch validation and local regeneration workflow
- docs/patches.md: add validation and maintenance section
- README.md: mention CI patch validation

## Testing

- reviewed all workflow insertions for correct scope, condition gating, and artifact upload placement
